### PR TITLE
chore: use java helper for templates

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -47,8 +47,6 @@ for version in versions:
     java.format_code(f'grpc-google-cloud-{service}-{version}/src')
     java.format_code(f'proto-google-cloud-{service}-{version}/src')
 
-common_templates = gcp.CommonTemplates()
-templates = common_templates.java_library()
-s.copy(templates, excludes=[
+java.common_templates(excludes=[
     'README.md'
 ])


### PR DESCRIPTION
We are cleaning up usage of common templates in synthtool. This allows us the cleanup usage in a centralized place rather than in 60+ repos