### PR TITLE
chore: Migrate pubsub synth.py to bazel

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -15,24 +15,19 @@
 """This script is used to synthesize generated parts of this library."""
 
 import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
 
 AUTOSYNTH_MULTIPLE_COMMITS = True
 
-gapic = gcp.GAPICGenerator()
-
 service = 'pubsub'
 versions = ['v1']
-config_pattern = '/google/pubsub/artman_pubsub.yaml'
 
 for version in versions:
-    java.gapic_library(
+    java.bazel_library(
         service=service,
         version=version,
-        config_pattern=config_pattern,
-        package_pattern='com.google.{service}.{version}',
-        gapic=gapic,
+        proto_path=f'google/{service}/{version}',
+        bazel_target=f'//google/{service}/{version}:google-cloud-{service}-{version}-java',
     )
     s.replace(
         '**/stub/SubscriberStubSettings.java',


### PR DESCRIPTION
This PR migrates only synth.py but does not commit the regenerated files. The generation was tested and it works, the updated files are not commited due to breaking changes not related to bazel migration.

**This PR should be pushed after the an already open PR with the braking changes: https://github.com/googleapis/java-pubsub/pull/113**
