### PR TITLE
docs: update libraries-bom

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you are using Maven with a BOM, add this to your pom.xml file:
   <dependency>
     <groupId>com.google.cloud</groupId>
     <artifactId>libraries-bom</artifactId>
-    <version>2.9.0</version>
+    <version>4.4.1</version>
     <type>pom</type>
     <scope>import</scope>
    </dependency>


### PR DESCRIPTION
Is the libraries-bom update automated in any way? I suspect our [docs page](https://cloud.google.com/pubsub/docs/quickstart-client-libraries#pubsub-client-libraries-java) reads directly from here.

The tests took over hours to finish. Is there a way to skip some of these tests for README changes?