### PR TITLE
feat: set up repo for samples

### DIFF
--- a/.kokoro/continuous/java11-samples.cfg
+++ b/.kokoro/continuous/java11-samples.cfg
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsub/.kokoro/run_samples_tests.sh"
+}

--- a/.kokoro/continuous/jave8-samples.cfg
+++ b/.kokoro/continuous/jave8-samples.cfg
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsub/.kokoro/run_samples_tests.sh"
+}
+© 2020 GitHub, Inc.

--- a/.kokoro/nightly/java11-samples.cfg
+++ b/.kokoro/nightly/java11-samples.cfg
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsub/.kokoro/run_samples_tests.sh"
+}

--- a/.kokoro/nightly/jave8-samples.cfg
+++ b/.kokoro/nightly/jave8-samples.cfg
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsub/.kokoro/run_samples_tests.sh"
+}
+© 2020 GitHub, Inc.

--- a/.kokoro/presubmit/java11-samples.cfg
+++ b/.kokoro/presubmit/java11-samples.cfg
@@ -1,0 +1,30 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsub/.kokoro/run_samples_tests.sh"
+}

--- a/.kokoro/presubmit/jave8-samples.cfg
+++ b/.kokoro/presubmit/jave8-samples.cfg
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Download secrets from Cloud Storage.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/java-docs-samples"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/java8"
+}
+
+# Tell trampoline which tests to run.
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/java-pubsub/.kokoro/run_samples_tests.sh"
+}
+© 2020 GitHub, Inc.

--- a/.kokoro/run_samples_tests.sh
+++ b/.kokoro/run_samples_tests.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# `-e` enables the script to automatically fail when a command fails
+# `-o pipefail` sets the exit code to the rightmost comment to exit with a non-zero
+set -eo pipefail
+
+echo "********** MAVEN INFO  ***********"
+mvn -v
+
+# Get the directory of the build script
+scriptDir=$(realpath $(dirname "${BASH_SOURCE[0]}"))
+## cd to the parent directory, i.e. the root of the git repo
+cd ${scriptDir}/..
+
+# include common functions
+source ${scriptDir}/common.sh
+
+# Attempt to install 3 times with exponential backoff (starting with 10 seconds)
+retry_with_backoff 3 10 \
+  mvn install -B -V \
+    -DskipTests=true \
+    -Dclirr.skip=true \
+    -Denforcer.skip=true \
+    -Dmaven.javadoc.skip=true \
+    -Dgcloud.download.skip=true \
+    -T 1C
+
+# Activate service account
+gcloud auth activate-service-account \
+    --key-file="$GOOGLE_APPLICATION_CREDENTIALS" \
+    --project="$GOOGLE_CLOUD_PROJECT"
+
+# Move into the samples directory
+cd samples/
+
+echo -e "\n******************** RUNNING SAMPLE TESTS ********************"
+
+mvn --fail-at-end clean verify

--- a/google-cloud-pubsub-bom/pom.xml
+++ b/google-cloud-pubsub-bom/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
   </parent>
 
   <name>Google Cloud pubsub BOM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
   </parent>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,16 @@
     <module>google-cloud-pubsub-bom</module>
   </modules>
 
+  <!--  // The samples CI build is configured to run with `-Penable-samples` (.kokoro/build.sh L78) -->
+  <profiles>
+    <profile>
+      <id>enable-samples</id>
+      <modules>
+        <module>samples</module>
+      </modules>
+    </profile>
+  </profiles>
+
   <reporting>
     <plugins>
       <plugin>


### PR DESCRIPTION
Modified these files to set up samples testing. A follow-up PR (#197) will add samples & tests.

```
        new file:   .kokoro/continuous/java11-samples.cfg
        new file:   .kokoro/continuous/jave8-samples.cfg
        new file:   .kokoro/nightly/java11-samples.cfg
        new file:   .kokoro/nightly/jave8-samples.cfg
        new file:   .kokoro/presubmit/java11-samples.cfg
        new file:   .kokoro/presubmit/jave8-samples.cfg
        new file:   .kokoro/run_samples_tests.sh
        modified:   pom.xml
```