### PR TITLE
samples: migrate subscriber samples and add tests (part 2)

### DIFF
--- a/samples/snippets/src/main/java/pubsub/SubscribeAsyncExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeAsyncExample.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_quickstart_subscriber]
+// [START pubsub_subscriber_async_pull]
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class SubscribeAsyncExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+
+    subscribeAsyncExample(projectId, subscriptionId);
+  }
+
+  public static void subscribeAsyncExample(String projectId, String subscriptionId) {
+    ProjectSubscriptionName subscriptionName =
+        ProjectSubscriptionName.of(projectId, subscriptionId);
+
+    // Instantiate an asynchronous message receiver.
+    MessageReceiver receiver =
+        new MessageReceiver() {
+          @Override
+          public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+            // Handle incoming message, then ack the received message.
+            System.out.println("Id: " + message.getMessageId());
+            System.out.println("Data: " + message.getData().toStringUtf8());
+            consumer.ack();
+          }
+        };
+
+    Subscriber subscriber = null;
+    try {
+      subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+      // Start the subscriber.
+      subscriber.startAsync().awaitRunning();
+      System.out.printf("Listening for messages on %s:\n", subscriptionName.toString());
+      // Allow the subscriber to run for 30s unless an unrecoverable error occurs.
+      subscriber.awaitTerminated(30, TimeUnit.SECONDS);
+    } catch (TimeoutException timeoutException) {
+      // Shut down the subscriber after 30s. Stop receiving messages.
+      subscriber.stopAsync();
+    }
+  }
+}
+// [END pubsub_subscriber_async_pull]
+// [END pubsub_quickstart_subscriber]

--- a/samples/snippets/src/main/java/pubsub/SubscribeSyncExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeSyncExample.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_subscriber_sync_pull]
+
+import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ReceivedMessage;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SubscribeSyncExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+    Integer numOfMessages = 10;
+
+    subscribeSyncExample(projectId, subscriptionId, numOfMessages);
+  }
+
+  public static void subscribeSyncExample(
+      String projectId, String subscriptionId, Integer numOfMessages) throws IOException {
+    SubscriberStubSettings subscriberStubSettings =
+        SubscriberStubSettings.newBuilder()
+            .setTransportChannelProvider(
+                SubscriberStubSettings.defaultGrpcTransportProviderBuilder()
+                    .setMaxInboundMessageSize(20 << 20) // 20 MB
+                    .build())
+            .build();
+
+    try (SubscriberStub subscriber = GrpcSubscriberStub.create(subscriberStubSettings)) {
+
+      String subscriptionName = ProjectSubscriptionName.format(projectId, subscriptionId);
+      PullRequest pullRequest =
+          PullRequest.newBuilder()
+              .setMaxMessages(numOfMessages)
+              .setSubscription(subscriptionName)
+              .build();
+
+      // Use pullCallable().futureCall to asynchronously perform this operation.
+      PullResponse pullResponse = subscriber.pullCallable().call(pullRequest);
+      List<String> ackIds = new ArrayList<>();
+      for (ReceivedMessage message : pullResponse.getReceivedMessagesList()) {
+        // Handle received message
+        // ...
+        ackIds.add(message.getAckId());
+      }
+      // Acknowledge received messages.
+      AcknowledgeRequest acknowledgeRequest =
+          AcknowledgeRequest.newBuilder()
+              .setSubscription(subscriptionName)
+              .addAllAckIds(ackIds)
+              .build();
+
+      // Use acknowledgeCallable().futureCall to asynchronously perform this operation.
+      subscriber.acknowledgeCallable().call(acknowledgeRequest);
+      System.out.println(pullResponse.getReceivedMessagesList());
+    }
+  }
+}
+// [END pubsub_subscriber_sync_pull]

--- a/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
@@ -1,5 +1,0 @@
-package pubsub;
-
-public class SubscribeSyncWithLeaseExample {
-
-}

--- a/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
@@ -1,0 +1,5 @@
+package pubsub;
+
+public class SubscribeSyncWithLeaseExample {
+
+}

--- a/samples/snippets/src/main/java/pubsub/SubscribeWithConcurrencyControlExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeWithConcurrencyControlExample.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_subscriber_concurrency_control]
+
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class SubscribeWithConcurrencyControlExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+
+    subscribeWithConcurrencyControlExample(projectId, subscriptionId);
+  }
+
+  public static void subscribeWithConcurrencyControlExample(
+      String projectId, String subscriptionId) {
+    ProjectSubscriptionName subscriptionName =
+        ProjectSubscriptionName.of(projectId, subscriptionId);
+
+    // Instantiate an asynchronous message receiver.
+    MessageReceiver receiver =
+        new MessageReceiver() {
+          @Override
+          public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+            // Handle incoming message, then ack the received message.
+            System.out.println("Id: " + message.getMessageId());
+            System.out.println("Data: " + message.getData().toStringUtf8());
+            consumer.ack();
+          }
+        };
+
+    Subscriber subscriber = null;
+
+    try {
+      // Provides an executor service for processing messages. The default `executorProvider` used
+      // by the subscriber has a default thread count of 5.
+      ExecutorProvider executorProvider =
+          InstantiatingExecutorProvider.newBuilder().setExecutorThreadCount(4).build();
+
+      // `setParallelPullCount` determines how many StreamingPull streams the subscriber will open
+      // to receive message. It defaults to 1. `setExecutorProvider` configures an executor for the
+      // subscriber to process messages. Here, the subscriber is configured to open 2 streams for
+      // receiving messages, each stream creates a new executor with 4 threads to help process the
+      // message callbacks. In total 2x4=8 threads are used for message processing.
+      subscriber =
+          Subscriber.newBuilder(subscriptionName, receiver)
+              .setParallelPullCount(2)
+              .setExecutorProvider(executorProvider)
+              .build();
+
+      // Start the subscriber.
+      subscriber.startAsync().awaitRunning();
+      System.out.printf("Listening for messages on %s:\n", subscriptionName.toString());
+      // Allow the subscriber to run for 30s unless an unrecoverable error occurs.
+      subscriber.awaitTerminated(30, TimeUnit.SECONDS);
+    } catch (TimeoutException timeoutException) {
+      // Shut down the subscriber after 30s. Stop receiving messages.
+      subscriber.stopAsync();
+    }
+  }
+}
+// [END pubsub_subscriber_concurrency_control]

--- a/samples/snippets/src/main/java/pubsub/SubscribeWithCustomAttributesExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeWithCustomAttributesExample.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_subscriber_async_pull_custom_attributes]
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class SubscribeWithCustomAttributesExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+
+    subscribeWithCustomAttributesExample(projectId, subscriptionId);
+  }
+
+  public static void subscribeWithCustomAttributesExample(String projectId, String subscriptionId) {
+    ProjectSubscriptionName subscriptionName =
+        ProjectSubscriptionName.of(projectId, subscriptionId);
+
+    // Instantiate an asynchronous message receiver.
+    MessageReceiver receiver =
+        new MessageReceiver() {
+          @Override
+          public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+            // Handle incoming message, then ack the received message.
+            System.out.println("Id: " + message.getMessageId());
+            System.out.println("Data: " + message.getData().toStringUtf8());
+            // Print message attributes.
+            message
+                .getAttributesMap()
+                .forEach((key, value) -> System.out.println(key + " = " + value));
+            consumer.ack();
+          }
+        };
+
+    Subscriber subscriber = null;
+    try {
+      subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+      // Start the subscriber.
+      subscriber.startAsync().awaitRunning();
+      System.out.printf("Listening for messages on %s:\n", subscriptionName.toString());
+      // Allow the subscriber to run for 30s unless an unrecoverable error occurs.
+      subscriber.awaitTerminated(30, TimeUnit.SECONDS);
+    } catch (TimeoutException timeoutException) {
+      // Shut down the subscriber after 30s. Stop receiving messages.
+      subscriber.stopAsync();
+    }
+  }
+}
+// [END pubsub_subscriber_async_pull_custom_attributes]

--- a/samples/snippets/src/main/java/pubsub/SubscribeWithErrorListenerExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeWithErrorListenerExample.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_subscriber_error_listener]
+
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class SubscribeWithErrorListenerExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+
+    // Provides an executor service for processing messages.
+    ExecutorProvider executorProvider =
+        InstantiatingExecutorProvider.newBuilder().setExecutorThreadCount(4).build();
+
+    subscribeWithErrorListenerExample(projectId, subscriptionId, executorProvider);
+  }
+
+  public static void subscribeWithErrorListenerExample(
+      String projectId, String subscriptionId, ExecutorProvider executorProvider) {
+    ProjectSubscriptionName subscriptionName =
+        ProjectSubscriptionName.of(projectId, subscriptionId);
+
+    // Instantiate an asynchronous message receiver.
+    MessageReceiver receiver =
+        new MessageReceiver() {
+          @Override
+          public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+            // Handle incoming message, then ack the received message.
+            System.out.println("Id: " + message.getMessageId());
+            System.out.println("Data: " + message.getData().toStringUtf8());
+            consumer.ack();
+          }
+        };
+
+    Subscriber subscriber = null;
+
+    try {
+      subscriber =
+          Subscriber.newBuilder(subscriptionName, receiver)
+              .setExecutorProvider(executorProvider)
+              .build();
+
+      // Listen for unrecoverable failures. Rebuild a subscriber and restart subscribing
+      // when the current subscriber encounters permanent errors.
+      subscriber.addListener(
+          new Subscriber.Listener() {
+            public void failed(Subscriber.State from, Throwable failure) {
+              System.out.println(failure.getStackTrace());
+              if (!executorProvider.getExecutor().isShutdown()) {
+                subscribeWithErrorListenerExample(projectId, subscriptionId, executorProvider);
+              }
+            }
+          },
+          MoreExecutors.directExecutor());
+
+      // Start the subscriber.
+      subscriber.startAsync().awaitRunning();
+      System.out.printf("Listening for messages on %s:\n", subscriptionName.toString());
+      // Allow the subscriber to run for 30s unless an unrecoverable error occurs.
+      subscriber.awaitTerminated(30, TimeUnit.SECONDS);
+    } catch (TimeoutException timeoutException) {
+      // Shut down the subscriber after 30s. Stop receiving messages.
+      subscriber.stopAsync();
+    }
+  }
+}
+// [END pubsub_subscriber_error_listener]

--- a/samples/snippets/src/main/java/pubsub/SubscribeWithFlowControlSettingsExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeWithFlowControlSettingsExample.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_subscriber_flow_settings]
+
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class SubscribeWithFlowControlSettingsExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+
+    subscribeWithFlowControlSettingsExample(projectId, subscriptionId);
+  }
+
+  public static void subscribeWithFlowControlSettingsExample(
+      String projectId, String subscriptionId) {
+    ProjectSubscriptionName subscriptionName =
+        ProjectSubscriptionName.of(projectId, subscriptionId);
+
+    // Instantiate an asynchronous message receiver.
+    MessageReceiver receiver =
+        new MessageReceiver() {
+          @Override
+          public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+            // Handle incoming message, then ack the received message.
+            System.out.println("Id: " + message.getMessageId());
+            System.out.println("Data: " + message.getData().toStringUtf8());
+            consumer.ack();
+          }
+        };
+
+    Subscriber subscriber = null;
+
+    // The subscriber will pause the message stream and stop receiving more messsages from the
+    // server if any one of the conditions is met.
+    FlowControlSettings flowControlSettings =
+        FlowControlSettings.newBuilder()
+            // 1,000 outstanding messages. Must be >0. It controls the maximum number of messages
+            // the subscriber receives before pausing the message stream.
+            .setMaxOutstandingElementCount(1000L)
+            // 100 MiB. Must be >0. It controls the maximum size of messages the subscriber
+            // receives before pausing the message stream.
+            .setMaxOutstandingRequestBytes(100L * 1024L * 1024L)
+            .build();
+
+    try {
+      subscriber =
+          Subscriber.newBuilder(subscriptionName, receiver)
+              .setFlowControlSettings(flowControlSettings)
+              .build();
+
+      // Start the subscriber.
+      subscriber.startAsync().awaitRunning();
+      System.out.printf("Listening for messages on %s:\n", subscriptionName.toString());
+      // Allow the subscriber to run for 30s unless an unrecoverable error occurs.
+      subscriber.awaitTerminated(30, TimeUnit.SECONDS);
+    } catch (TimeoutException timeoutException) {
+      // Shut down the subscriber after 30s. Stop receiving messages.
+      subscriber.stopAsync();
+    }
+  }
+}
+// [END pubsub_subscriber_flow_settings]

--- a/samples/snippets/src/test/java/pubsub/PublisherIT.java
+++ b/samples/snippets/src/test/java/pubsub/PublisherIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pubsub;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/samples/snippets/src/test/java/pubsub/SubscriberIT.java
+++ b/samples/snippets/src/test/java/pubsub/SubscriberIT.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ProjectTopicName;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.Topic;
+import com.google.pubsub.v1.TopicName;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+public class SubscriberIT {
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+
+  private static final String projectId = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String _suffix = UUID.randomUUID().toString();
+  private static final String topicId = "publisher-test-topic-" + _suffix;
+  private static final String subscriptionId = "publisher-test-subscription-" + _suffix;
+  private static final TopicName topicName = TopicName.of(projectId, topicId);
+  private static final ProjectSubscriptionName subscriptionName =
+      ProjectSubscriptionName.of(projectId, subscriptionId);
+  private static final ExecutorProvider executorProvider =
+      InstantiatingExecutorProvider.newBuilder().setExecutorThreadCount(4).build();
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+  }
+
+  // Helper function to publish some messages.
+  private static void publishSomeMessages(Integer numOfMessages) throws Exception {
+    ProjectTopicName topicName = ProjectTopicName.of(projectId, topicId);
+    Publisher publisher = Publisher.newBuilder(topicName).build();
+    List<ApiFuture<String>> messageIdFutures = new ArrayList<>();
+    for (int i = 0; i < numOfMessages; i++) {
+      ByteString data = ByteString.copyFromUtf8("Hello " + i);
+      PubsubMessage pubsubMessage =
+          PubsubMessage.newBuilder()
+              .setData(data)
+              .putAllAttributes(ImmutableMap.of("year", "2020", "author", "unknown"))
+              .build();
+      ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);
+      messageIdFutures.add(messageIdFuture);
+    }
+    ApiFutures.allAsList(messageIdFutures).get();
+  }
+
+  @Rule public Timeout globalTimeout = Timeout.seconds(600); // 10 minute timeout
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    System.setOut(out);
+
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      Topic topic = Topic.newBuilder().setName(topicName.toString()).build();
+      topicAdminClient.createTopic(topic);
+    }
+
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      Subscription subscription =
+          Subscription.newBuilder()
+              .setName(subscriptionName.toString())
+              .setTopic(topicName.toString())
+              .build();
+      subscriptionAdminClient.createSubscription(subscription);
+    }
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      subscriptionAdminClient.deleteSubscription(subscriptionName.toString());
+    }
+
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      topicAdminClient.deleteTopic(topicName.toString());
+    }
+
+    System.setOut(null);
+  }
+
+  @Test
+  public void testSubscriber() throws Exception {
+    publishSomeMessages(1);
+    // Test subscribe asynchronously.
+    SubscribeAsyncExample.subscribeAsyncExample(projectId, subscriptionId);
+    assertThat(bout.toString()).contains("Data: Hello 0");
+
+    publishSomeMessages(1);
+    bout.reset();
+    // Test subscribe with custom attributes.
+    SubscribeWithCustomAttributesExample.subscribeWithCustomAttributesExample(
+        projectId, subscriptionId);
+    assertThat(bout.toString()).contains("Data: Hello 0");
+    assertThat(bout.toString()).contains("author = unknown");
+    assertThat(bout.toString()).contains("year = 2020");
+
+    publishSomeMessages(5);
+    bout.reset();
+    // Test subscribe with error listener.
+    SubscribeWithErrorListenerExample.subscribeWithErrorListenerExample(
+        projectId, subscriptionId, executorProvider);
+    assertThat(bout.toString()).contains("Data: Hello 0");
+
+    publishSomeMessages(200);
+    bout.reset();
+    // Test subscribe with flow control settings.
+    SubscribeWithFlowControlSettingsExample.subscribeWithFlowControlSettingsExample(
+        projectId, subscriptionId);
+    for (int i = 0; i < 200; i++) {
+      assertThat(bout.toString()).contains("Data: Hello " + i);
+    }
+
+    publishSomeMessages(100);
+    bout.reset();
+    // Test subscribe with concurrency control.
+    SubscribeWithConcurrencyControlExample.subscribeWithConcurrencyControlExample(
+        projectId, subscriptionId);
+    for (int i = 0; i < 100; i++) {
+      assertThat(bout.toString()).contains("Data: Hello " + i);
+    }
+
+    publishSomeMessages(10);
+    bout.reset();
+    // Test subscribe synchronously.
+    SubscribeSyncExample.subscribeSyncExample(projectId, subscriptionId, 10);
+    for (int i = 0; i < 10; i++) {
+      assertThat(bout.toString()).contains("Hello " + i);
+    }
+  }
+}


### PR DESCRIPTION
Migrate publisher samples, currently living in [`google-cloud-java`](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/pubsub/snippets) (no tests were written for them) and [`java-docs-samples`](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/pubsub/cloud-client) (incomplete set of samples), here.  This is **part 2 of 5** of Pub/Sub Java samples migration. 

Added tests for them too.  

Part 1: migrate publisher samples
**-> Part 2: migrate subscriber samples**
Part 3: migrate topic admin samples
Part 4: migrate subscription admin samples
Part 5: migrate iam, emulator, and other miscellaneous samples
Part 6: update docs. add notes to old samples. 