### PR TITLE
samples: migrate admin samples and add tests (part 3)

### DIFF
--- a/samples/snippets/src/main/java/pubsub/CreatePullSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsub/CreatePullSubscriptionExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
 
 public class CreatePullSubscriptionExample {
   public static void main(String... args) throws Exception {
@@ -35,7 +36,7 @@ public class CreatePullSubscriptionExample {
   }
 
   public static void createPullSubscriptionExample(
-      String projectId, String subscriptionId, String topicId) throws Exception {
+      String projectId, String subscriptionId, String topicId) throws IOException {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       TopicName topicName = TopicName.of(projectId, topicId);
       ProjectSubscriptionName subscriptionName =

--- a/samples/snippets/src/main/java/pubsub/CreatePullSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsub/CreatePullSubscriptionExample.java
@@ -46,7 +46,7 @@ public class CreatePullSubscriptionExample {
       Subscription subscription =
           subscriptionAdminClient.createSubscription(
               subscriptionName, topicName, PushConfig.getDefaultInstance(), 10);
-      System.out.println("Create pull subscription: " + subscription.getName());
+      System.out.println("Created pull subscription: " + subscription.getName());
     }
   }
 }

--- a/samples/snippets/src/main/java/pubsub/CreatePullSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsub/CreatePullSubscriptionExample.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_create_pull_subscription]
+
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.TopicName;
+
+public class CreatePullSubscriptionExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+    String topicId = "your-topic-id";
+
+    createPullSubscriptionExample(projectId, subscriptionId, topicId);
+  }
+
+  public static void createPullSubscriptionExample(
+      String projectId, String subscriptionId, String topicId) throws Exception {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      TopicName topicName = TopicName.of(projectId, topicId);
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+      // Create a pull subscription with default acknowledgement deadline of 10 seconds.
+      // Messages not successfully acknowledged within 10 seconds will get resent by the server.
+      Subscription subscription =
+          subscriptionAdminClient.createSubscription(
+              subscriptionName, topicName, PushConfig.getDefaultInstance(), 10);
+      System.out.println("Create pull subscription: " + subscription.getName());
+    }
+  }
+}
+// [END pubsub_create_pull_subscription]

--- a/samples/snippets/src/main/java/pubsub/CreatePushSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsub/CreatePushSubscriptionExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.Subscription;
 import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
 
 public class CreatePushSubscriptionExample {
   public static void main(String... args) throws Exception {
@@ -37,7 +38,7 @@ public class CreatePushSubscriptionExample {
 
   public static void createPushSubscriptionExample(
       String projectId, String subscriptionId, String topicId, String pushEndpoint)
-      throws Exception {
+      throws IOException {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       TopicName topicName = TopicName.of(projectId, topicId);
       ProjectSubscriptionName subscriptionName =

--- a/samples/snippets/src/main/java/pubsub/CreatePushSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsub/CreatePushSubscriptionExample.java
@@ -49,7 +49,7 @@ public class CreatePushSubscriptionExample {
       // Messages not successfully acknowledged within 10 seconds will get resent by the server.
       Subscription subscription =
           subscriptionAdminClient.createSubscription(subscriptionName, topicName, pushConfig, 10);
-      System.out.println("Create push subscription: " + subscription.getName());
+      System.out.println("Created push subscription: " + subscription.getName());
     }
   }
 }

--- a/samples/snippets/src/main/java/pubsub/CreatePushSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsub/CreatePushSubscriptionExample.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_create_push_subscription]
+
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.TopicName;
+
+public class CreatePushSubscriptionExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+    String topicId = "your-topic-id";
+    String pushEndpoint = "https://my-test-project.appspot.com/push";
+
+    createPushSubscriptionExample(projectId, subscriptionId, topicId, pushEndpoint);
+  }
+
+  public static void createPushSubscriptionExample(
+      String projectId, String subscriptionId, String topicId, String pushEndpoint)
+      throws Exception {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      TopicName topicName = TopicName.of(projectId, topicId);
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+      PushConfig pushConfig = PushConfig.newBuilder().setPushEndpoint(pushEndpoint).build();
+
+      // Create a push subscription with default acknowledgement deadline of 10 seconds.
+      // Messages not successfully acknowledged within 10 seconds will get resent by the server.
+      Subscription subscription =
+          subscriptionAdminClient.createSubscription(subscriptionName, topicName, pushConfig, 10);
+      System.out.println("Create push subscription: " + subscription.getName());
+    }
+  }
+}
+// [END pubsub_create_push_subscription]

--- a/samples/snippets/src/main/java/pubsub/CreateSubscriptionWithDeadLetterPolicyExample.java
+++ b/samples/snippets/src/main/java/pubsub/CreateSubscriptionWithDeadLetterPolicyExample.java
@@ -23,6 +23,7 @@ import com.google.pubsub.v1.DeadLetterPolicy;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.Subscription;
+import java.io.IOException;
 
 public class CreateSubscriptionWithDeadLetterPolicyExample {
 
@@ -44,7 +45,7 @@ public class CreateSubscriptionWithDeadLetterPolicyExample {
 
   public static void createSubscriptionWithDeadLetterPolicyExample(
       String projectId, String subscriptionId, String topicId, String deadLetterTopicId)
-      throws Exception {
+      throws IOException {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
 
       ProjectTopicName topicName = ProjectTopicName.of(projectId, topicId);

--- a/samples/snippets/src/main/java/pubsub/CreateTopicExample.java
+++ b/samples/snippets/src/main/java/pubsub/CreateTopicExample.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_create_topic]
+
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.pubsub.v1.Topic;
+import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
+
+public class CreateTopicExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String topicId = "your-topic-id";
+
+    createTopicExample(projectId, topicId);
+  }
+
+  public static void createTopicExample(String projectId, String topicId) throws IOException {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      TopicName topicName = TopicName.of(projectId, topicId);
+      Topic topic = topicAdminClient.createTopic(topicName);
+      System.out.println("Created topic: " + topic.getName());
+    }
+  }
+}
+// [END pubsub_create_topic]

--- a/samples/snippets/src/main/java/pubsub/CreateTopicExample.java
+++ b/samples/snippets/src/main/java/pubsub/CreateTopicExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/DeleteSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsub/DeleteSubscriptionExample.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_delete_subscription]
+
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+
+public class DeleteSubscriptionExample {
+
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+
+    deleteSubscriptionExample(projectId, subscriptionId);
+  }
+
+  public static void deleteSubscriptionExample(String projectId, String subscriptionId)
+      throws Exception {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+      try {
+        subscriptionAdminClient.deleteSubscription(subscriptionName);
+        System.out.println("Deleted subscription.");
+      } catch (NotFoundException e) {
+        System.out.println(e.getMessage());
+      }
+    }
+  }
+}
+// [END pubsub_delete_subscription]

--- a/samples/snippets/src/main/java/pubsub/DeleteSubscriptionExample.java
+++ b/samples/snippets/src/main/java/pubsub/DeleteSubscriptionExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ package pubsub;
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
 import com.google.pubsub.v1.ProjectSubscriptionName;
+import java.io.IOException;
 
 public class DeleteSubscriptionExample {
 
@@ -33,7 +34,7 @@ public class DeleteSubscriptionExample {
   }
 
   public static void deleteSubscriptionExample(String projectId, String subscriptionId)
-      throws Exception {
+      throws IOException {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       ProjectSubscriptionName subscriptionName =
           ProjectSubscriptionName.of(projectId, subscriptionId);

--- a/samples/snippets/src/main/java/pubsub/DeleteTopicExample.java
+++ b/samples/snippets/src/main/java/pubsub/DeleteTopicExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/DeleteTopicExample.java
+++ b/samples/snippets/src/main/java/pubsub/DeleteTopicExample.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_delete_topic]
+
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
+
+public class DeleteTopicExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String topicId = "your-topic-id";
+
+    deleteTopicExample(projectId, topicId);
+  }
+
+  public static void deleteTopicExample(String projectId, String topicId) throws IOException {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      TopicName topicName = TopicName.of(projectId, topicId);
+      try {
+        topicAdminClient.deleteTopic(topicName);
+        System.out.println("Deleted topic.");
+      } catch (NotFoundException e) {
+        System.out.println(e.getMessage());
+      }
+    }
+  }
+}
+// [END pubsub_delete_topic]

--- a/samples/snippets/src/main/java/pubsub/GetSubscriptionPolicyExample.java
+++ b/samples/snippets/src/main/java/pubsub/GetSubscriptionPolicyExample.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_get_subscription_policy]
+
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import java.io.IOException;
+
+public class GetSubscriptionPolicyExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+
+    getSubscriptionPolicyExample(projectId, subscriptionId);
+  }
+
+  public static void getSubscriptionPolicyExample(String projectId, String subscriptionId)
+      throws IOException {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+      GetIamPolicyRequest getIamPolicyRequest =
+          GetIamPolicyRequest.newBuilder().setResource(subscriptionName.toString()).build();
+      Policy policy = subscriptionAdminClient.getIamPolicy(getIamPolicyRequest);
+      System.out.println("Subscription policy: " + policy);
+    }
+  }
+}
+// [END pubsub_get_subscription_policy]

--- a/samples/snippets/src/main/java/pubsub/GetSubscriptionPolicyExample.java
+++ b/samples/snippets/src/main/java/pubsub/GetSubscriptionPolicyExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/GetTopicPolicyExample.java
+++ b/samples/snippets/src/main/java/pubsub/GetTopicPolicyExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/GetTopicPolicyExample.java
+++ b/samples/snippets/src/main/java/pubsub/GetTopicPolicyExample.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_get_topic_policy]
+
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
+
+public class GetTopicPolicyExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String topicId = "your-topic-id";
+
+    getTopicPolicyExample(projectId, topicId);
+  }
+
+  public static void getTopicPolicyExample(String projectId, String topicId) throws IOException {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      TopicName topicName = TopicName.of(projectId, topicId);
+      GetIamPolicyRequest getIamPolicyRequest =
+          GetIamPolicyRequest.newBuilder().setResource(topicName.toString()).build();
+      Policy policy = topicAdminClient.getIamPolicy(getIamPolicyRequest);
+      System.out.println("Topic policy: " + policy);
+    }
+  }
+}
+// [END pubsub_get_topic_policy]

--- a/samples/snippets/src/main/java/pubsub/ListSubscriptionsInProjectExample.java
+++ b/samples/snippets/src/main/java/pubsub/ListSubscriptionsInProjectExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/ListSubscriptionsInProjectExample.java
+++ b/samples/snippets/src/main/java/pubsub/ListSubscriptionsInProjectExample.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_list_subscriptions]
+
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.Subscription;
+import java.io.IOException;
+
+public class ListSubscriptionsInProjectExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+
+    listSubscriptionInProjectExample(projectId);
+  }
+
+  public static void listSubscriptionInProjectExample(String projectId) throws IOException {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      ProjectName projectName = ProjectName.of(projectId);
+      for (Subscription subscription :
+          subscriptionAdminClient.listSubscriptions(projectName).iterateAll()) {
+        System.out.println(subscription.getName());
+      }
+      System.out.println("Listed all the subscriptions in the project.");
+    }
+  }
+}
+// [END pubsub_list_subscriptions]

--- a/samples/snippets/src/main/java/pubsub/ListSubscriptionsInTopicExample.java
+++ b/samples/snippets/src/main/java/pubsub/ListSubscriptionsInTopicExample.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_list_topic_subscriptions]
+
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
+
+public class ListSubscriptionsInTopicExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String topicId = "your-topic-id";
+
+    listSubscriptionInTopicExample(projectId, topicId);
+  }
+
+  public static void listSubscriptionInTopicExample(String projectId, String topicId)
+      throws IOException {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      TopicName topicName = TopicName.of(projectId, topicId);
+      for (String subscription : topicAdminClient.listTopicSubscriptions(topicName).iterateAll()) {
+        System.out.println(subscription);
+      }
+      System.out.println("Listed all the subscriptions in the topic.");
+    }
+  }
+}
+// [END pubsub_list_topic_subscriptions]

--- a/samples/snippets/src/main/java/pubsub/ListSubscriptionsInTopicExample.java
+++ b/samples/snippets/src/main/java/pubsub/ListSubscriptionsInTopicExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/ListTopicsExample.java
+++ b/samples/snippets/src/main/java/pubsub/ListTopicsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/ListTopicsExample.java
+++ b/samples/snippets/src/main/java/pubsub/ListTopicsExample.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_list_topics]
+
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.Topic;
+import java.io.IOException;
+
+public class ListTopicsExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+
+    listTopicsExample(projectId);
+  }
+
+  public static void listTopicsExample(String projectId) throws IOException {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      ProjectName projectName = ProjectName.of(projectId);
+      for (Topic topic : topicAdminClient.listTopics(projectName).iterateAll()) {
+        System.out.println(topic.getName());
+      }
+      System.out.println("Listed all topics.");
+    }
+  }
+}
+// [END pubsub_list_topics]

--- a/samples/snippets/src/main/java/pubsub/PublishWithBatchSettingsExample.java
+++ b/samples/snippets/src/main/java/pubsub/PublishWithBatchSettingsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/PublishWithConcurrencyControlExample.java
+++ b/samples/snippets/src/main/java/pubsub/PublishWithConcurrencyControlExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/PublishWithCustomAttributesExample.java
+++ b/samples/snippets/src/main/java/pubsub/PublishWithCustomAttributesExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/PublishWithErrorHandlerExample.java
+++ b/samples/snippets/src/main/java/pubsub/PublishWithErrorHandlerExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/PublishWithRetrySettingsExample.java
+++ b/samples/snippets/src/main/java/pubsub/PublishWithRetrySettingsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/PublisherExample.java
+++ b/samples/snippets/src/main/java/pubsub/PublisherExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/SetSubscriptionPolicyExample.java
+++ b/samples/snippets/src/main/java/pubsub/SetSubscriptionPolicyExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/SetSubscriptionPolicyExample.java
+++ b/samples/snippets/src/main/java/pubsub/SetSubscriptionPolicyExample.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_set_subscription_policy]
+
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import java.io.IOException;
+
+public class SetSubscriptionPolicyExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+
+    setSubscriptionPolicyExample(projectId, subscriptionId);
+  }
+
+  public static void setSubscriptionPolicyExample(String projectId, String subscriptionId)
+      throws IOException {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+      GetIamPolicyRequest getIamPolicyRequest =
+          GetIamPolicyRequest.newBuilder().setResource(subscriptionName.toString()).build();
+      Policy oldPolicy = subscriptionAdminClient.getIamPolicy(getIamPolicyRequest);
+
+      // Create new role -> members binding
+      Binding binding =
+          Binding.newBuilder().setRole("roles/pubsub.editor").addMembers("allUsers").build();
+
+      // Add new binding to updated policy
+      Policy updatedPolicy = Policy.newBuilder(oldPolicy).addBindings(binding).build();
+
+      SetIamPolicyRequest setIamPolicyRequest =
+          SetIamPolicyRequest.newBuilder()
+              .setResource(subscriptionName.toString())
+              .setPolicy(updatedPolicy)
+              .build();
+      Policy newPolicy = subscriptionAdminClient.setIamPolicy(setIamPolicyRequest);
+      System.out.println("New subscription policy: " + newPolicy);
+    }
+  }
+}
+// [END pubsub_set_subscription_policy]

--- a/samples/snippets/src/main/java/pubsub/SetTopicPolicyExample.java
+++ b/samples/snippets/src/main/java/pubsub/SetTopicPolicyExample.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.iam.v1.Binding;
+import com.google.iam.v1.GetIamPolicyRequest;
+import com.google.iam.v1.Policy;
+import com.google.iam.v1.SetIamPolicyRequest;
+import com.google.pubsub.v1.TopicName;
+import java.io.IOException;
+
+public class SetTopicPolicyExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String topicId = "your-topic-id";
+
+    setTopicPolicyExample(projectId, topicId);
+  }
+
+  public static void setTopicPolicyExample(String projectId, String topicId) throws IOException {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      TopicName topicName = TopicName.of(projectId, topicId);
+      GetIamPolicyRequest getIamPolicyRequest =
+          GetIamPolicyRequest.newBuilder().setResource(topicName.toString()).build();
+      Policy oldPolicy = topicAdminClient.getIamPolicy(getIamPolicyRequest);
+
+      // Create new role -> members binding
+      Binding binding =
+          Binding.newBuilder().setRole("roles/pubsub.editor").addMembers("allUsers").build();
+
+      // Add new binding to updated policy
+      Policy updatedPolicy = Policy.newBuilder(oldPolicy).addBindings(binding).build();
+
+      SetIamPolicyRequest setIamPolicyRequest =
+          SetIamPolicyRequest.newBuilder()
+              .setResource(topicName.toString())
+              .setPolicy(updatedPolicy)
+              .build();
+      Policy newPolicy = topicAdminClient.setIamPolicy(setIamPolicyRequest);
+      System.out.println("New topic policy: " + newPolicy);
+    }
+  }
+}

--- a/samples/snippets/src/main/java/pubsub/SetTopicPolicyExample.java
+++ b/samples/snippets/src/main/java/pubsub/SetTopicPolicyExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package pubsub;
+
+// [START pubsub_set_topic_policy]
 
 import com.google.cloud.pubsub.v1.TopicAdminClient;
 import com.google.iam.v1.Binding;
@@ -57,3 +59,4 @@ public class SetTopicPolicyExample {
     }
   }
 }
+// [END pubsub_set_topic_policy]

--- a/samples/snippets/src/main/java/pubsub/SubscribeAsyncExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeAsyncExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/SubscribeSyncExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeSyncExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/SubscribeWithConcurrencyControlExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeWithConcurrencyControlExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/SubscribeWithCustomAttributesExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeWithCustomAttributesExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/SubscribeWithErrorListenerExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeWithErrorListenerExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/SubscribeWithFlowControlSettingsExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeWithFlowControlSettingsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/TestSubscriptionPermissionsExample.java
+++ b/samples/snippets/src/main/java/pubsub/TestSubscriptionPermissionsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/TestSubscriptionPermissionsExample.java
+++ b/samples/snippets/src/main/java/pubsub/TestSubscriptionPermissionsExample.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_test_subscription_permissions]
+
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+public class TestSubscriptionPermissionsExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+
+    testSubscriptionPermissionsExample(projectId, subscriptionId);
+  }
+
+  public static void testSubscriptionPermissionsExample(String projectId, String subscriptionId)
+      throws IOException {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+
+      List<String> permissions = new LinkedList<>();
+      permissions.add("pubsub.subscriptions.consume");
+      permissions.add("pubsub.subscriptions.update");
+
+      TestIamPermissionsRequest testIamPermissionsRequest =
+          TestIamPermissionsRequest.newBuilder()
+              .setResource(subscriptionName.toString())
+              .addAllPermissions(permissions)
+              .build();
+
+      TestIamPermissionsResponse testedPermissionsResponse =
+          subscriptionAdminClient.testIamPermissions(testIamPermissionsRequest);
+
+      System.out.println("Tested:\n" + testedPermissionsResponse);
+    }
+  }
+}
+// [END pubsub_test_subscription_permissions]

--- a/samples/snippets/src/main/java/pubsub/TestTopicPermissionsExample.java
+++ b/samples/snippets/src/main/java/pubsub/TestTopicPermissionsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/main/java/pubsub/TestTopicPermissionsExample.java
+++ b/samples/snippets/src/main/java/pubsub/TestTopicPermissionsExample.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_test_topic_permissions]
+
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.iam.v1.TestIamPermissionsRequest;
+import com.google.iam.v1.TestIamPermissionsResponse;
+import com.google.pubsub.v1.ProjectTopicName;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+public class TestTopicPermissionsExample {
+
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String topicId = "your-topic-id";
+
+    testTopicPermissionsExample(projectId, topicId);
+  }
+
+  public static void testTopicPermissionsExample(String projectId, String topicId)
+      throws IOException {
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      ProjectTopicName topicName = ProjectTopicName.of(projectId, topicId);
+
+      List<String> permissions = new LinkedList<>();
+      permissions.add("pubsub.topics.attachSubscription");
+      permissions.add("pubsub.topics.publish");
+      permissions.add("pubsub.topics.update");
+
+      TestIamPermissionsRequest testIamPermissionsRequest =
+          TestIamPermissionsRequest.newBuilder()
+              .setResource(topicName.toString())
+              .addAllPermissions(permissions)
+              .build();
+
+      TestIamPermissionsResponse testedPermissionsResponse =
+          topicAdminClient.testIamPermissions(testIamPermissionsRequest);
+
+      System.out.println("Tested:\n" + testedPermissionsResponse);
+    }
+  }
+}
+// [END pubsub_test_topic_permissions]

--- a/samples/snippets/src/main/java/pubsub/UpdatePushConfigurationExample.java
+++ b/samples/snippets/src/main/java/pubsub/UpdatePushConfigurationExample.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+// [START pubsub_update_push_configuration]
+
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.Subscription;
+import java.io.IOException;
+
+public class UpdatePushConfigurationExample {
+  public static void main(String... args) throws Exception {
+    // TODO(developer): Replace these variables before running the sample.
+    String projectId = "your-project-id";
+    String subscriptionId = "your-subscription-id";
+    String pushEndpoint = "https://my-test-project.appspot.com/push";
+
+    updatePushConfigurationExample(projectId, subscriptionId, pushEndpoint);
+  }
+
+  public static void updatePushConfigurationExample(
+      String projectId, String subscriptionId, String pushEndpoint) throws IOException {
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      ProjectSubscriptionName subscriptionName =
+          ProjectSubscriptionName.of(projectId, subscriptionId);
+      PushConfig pushConfig = PushConfig.newBuilder().setPushEndpoint(pushEndpoint).build();
+      subscriptionAdminClient.modifyPushConfig(subscriptionName, pushConfig);
+      Subscription subscription = subscriptionAdminClient.getSubscription(subscriptionName);
+      System.out.println(
+          "Updated push endpoint to: " + subscription.getPushConfig().getPushEndpoint());
+    }
+  }
+}
+// [END pubsub_update_push_configuration]

--- a/samples/snippets/src/main/java/pubsub/UpdatePushConfigurationExample.java
+++ b/samples/snippets/src/main/java/pubsub/UpdatePushConfigurationExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/samples/snippets/src/test/java/pubsub/AdminIT.java
+++ b/samples/snippets/src/test/java/pubsub/AdminIT.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pubsub;
+
+import static com.google.common.truth.Truth.assertThat;
+import static junit.framework.TestCase.assertNotNull;
+
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ProjectTopicName;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+public class AdminIT {
+  private ByteArrayOutputStream bout;
+  private PrintStream out;
+
+  private static final String projectId = System.getenv("GOOGLE_CLOUD_PROJECT");
+  private static final String _suffix = UUID.randomUUID().toString();
+  private static final String topicId = "iam-topic-" + _suffix;
+  private static final String pullSubscriptionId = "iam-pull-subscription-" + _suffix;
+  private static final String pushSubscriptionId = "iam-push-subscription-" + _suffix;
+  private static final String pushEndpoint = "https://my-test-project.appspot.com/push";
+
+  private static final ProjectTopicName topicName = ProjectTopicName.of(projectId, topicId);
+  private static final ProjectSubscriptionName pullSubscriptionName =
+      ProjectSubscriptionName.of(projectId, pullSubscriptionId);
+  private static final ProjectSubscriptionName pushSubscriptionName =
+      ProjectSubscriptionName.of(projectId, pushSubscriptionId);
+
+  private static void requireEnvVar(String varName) {
+    assertNotNull(
+        "Environment variable " + varName + " is required to perform these tests.",
+        System.getenv(varName));
+  }
+
+  @Rule public Timeout globalTimeout = Timeout.seconds(300); // 5 minute timeout
+
+  @BeforeClass
+  public static void checkRequirements() {
+    requireEnvVar("GOOGLE_CLOUD_PROJECT");
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    bout = new ByteArrayOutputStream();
+    out = new PrintStream(bout);
+    System.setOut(out);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    // Delete the subscriptions if they have not been cleaned.
+    try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
+      try {
+        subscriptionAdminClient.deleteSubscription(pullSubscriptionName);
+        subscriptionAdminClient.deleteSubscription(pushSubscriptionName);
+      } catch (NotFoundException e) {
+      }
+    }
+
+    // Delete the topic if it has not been cleaned.
+    try (TopicAdminClient topicAdminClient = TopicAdminClient.create()) {
+      topicAdminClient.deleteTopic(topicName.toString());
+    } catch (NotFoundException e) {
+    }
+    System.setOut(null);
+  }
+
+  @Test
+  public void testAdmin() throws Exception {
+    // Test create topic.
+    CreateTopicExample.createTopicExample(projectId, topicId);
+    assertThat(bout.toString()).contains("Created topic: " + topicName.toString());
+
+    bout.reset();
+    // Test create pull subscription.
+    CreatePullSubscriptionExample.createPullSubscriptionExample(
+        projectId, pullSubscriptionId, topicId);
+    assertThat(bout.toString())
+        .contains("Create pull subscription: " + pullSubscriptionName.toString());
+
+    bout.reset();
+    // Test create push subscription.
+    CreatePushSubscriptionExample.createPushSubscriptionExample(
+        projectId, pushSubscriptionId, topicId, pushEndpoint);
+    assertThat(bout.toString())
+        .contains("Create push subscription: " + pushSubscriptionName.toString());
+
+    bout.reset();
+    // Test list topics in project.
+    ListTopicsExample.listTopicsExample(projectId);
+    assertThat(bout.toString()).contains("Listed all topics.");
+
+    bout.reset();
+    // Test list subscriptions in topic.
+    ListSubscriptionsInTopicExample.listSubscriptionInTopicExample(projectId, topicId);
+    assertThat(bout.toString()).contains("Listed all the subscriptions in the topic.");
+
+    bout.reset();
+    ListSubscriptionsInProjectExample.listSubscriptionInProjectExample(projectId);
+    // Test list subscriptions in project.
+    assertThat(bout.toString()).contains("Listed all the subscriptions in the project");
+
+    bout.reset();
+    // Test update push configuration.
+    UpdatePushConfigurationExample.updatePushConfigurationExample(
+        projectId, pullSubscriptionId, pushEndpoint);
+    assertThat(bout.toString()).contains("Updated push endpoint to: " + pushEndpoint);
+
+    bout.reset();
+    // Test get topic IAM policy.
+    GetTopicPolicyExample.getTopicPolicyExample(projectId, topicId);
+    assertThat(bout.toString()).contains("Topic policy:");
+
+    bout.reset();
+    // Test get subscription IAM policy.
+    GetSubscriptionPolicyExample.getSubscriptionPolicyExample(projectId, pullSubscriptionId);
+    assertThat(bout.toString()).contains("Subscription policy:");
+
+    bout.reset();
+    // Test set topic IAM policy.
+    SetTopicPolicyExample.setTopicPolicyExample(projectId, topicId);
+    assertThat(bout.toString()).contains("New topic policy:");
+
+    bout.reset();
+    // Test set subscription IAM policy.
+    SetSubscriptionPolicyExample.setSubscriptionPolicyExample(projectId, pullSubscriptionId);
+    assertThat(bout.toString()).contains("New subscription policy:");
+
+    bout.reset();
+    // Test topic permissions.
+    TestTopicPermissionsExample.testTopicPermissionsExample(projectId, topicId);
+    assertThat(bout.toString()).contains("permissions: \"pubsub.topics.attachSubscription\"");
+    assertThat(bout.toString()).contains("permissions: \"pubsub.topics.publish\"");
+    assertThat(bout.toString()).contains("permissions: \"pubsub.topics.update\"");
+
+    bout.reset();
+    TestSubscriptionPermissionsExample.testSubscriptionPermissionsExample(
+        projectId, pullSubscriptionId);
+    // Test subscription permissions.
+    assertThat(bout.toString()).contains("permissions: \"pubsub.subscriptions.consume\"");
+    assertThat(bout.toString()).contains("permissions: \"pubsub.subscriptions.update\"");
+
+    bout.reset();
+    // Test delete subscription. Run twice to delete both pull and push subscriptions.
+    DeleteSubscriptionExample.deleteSubscriptionExample(projectId, pullSubscriptionId);
+    DeleteSubscriptionExample.deleteSubscriptionExample(projectId, pushSubscriptionId);
+    assertThat(bout.toString()).contains("Deleted subscription.");
+
+    bout.reset();
+    // Test delete topic.
+    DeleteTopicExample.deleteTopicExample(projectId, topicId);
+    assertThat(bout.toString()).contains("Deleted topic.");
+  }
+}

--- a/samples/snippets/src/test/java/pubsub/AdminIT.java
+++ b/samples/snippets/src/test/java/pubsub/AdminIT.java
@@ -101,14 +101,14 @@ public class AdminIT {
     CreatePullSubscriptionExample.createPullSubscriptionExample(
         projectId, pullSubscriptionId, topicId);
     assertThat(bout.toString())
-        .contains("Create pull subscription: " + pullSubscriptionName.toString());
+        .contains("Created pull subscription: " + pullSubscriptionName.toString());
 
     bout.reset();
     // Test create push subscription.
     CreatePushSubscriptionExample.createPushSubscriptionExample(
         projectId, pushSubscriptionId, topicId, pushEndpoint);
     assertThat(bout.toString())
-        .contains("Create push subscription: " + pushSubscriptionName.toString());
+        .contains("Created push subscription: " + pushSubscriptionName.toString());
 
     bout.reset();
     // Test list topics in project.

--- a/samples/snippets/src/test/java/pubsub/SubscriberIT.java
+++ b/samples/snippets/src/test/java/pubsub/SubscriberIT.java
@@ -52,8 +52,8 @@ public class SubscriberIT {
 
   private static final String projectId = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String _suffix = UUID.randomUUID().toString();
-  private static final String topicId = "publisher-test-topic-" + _suffix;
-  private static final String subscriptionId = "publisher-test-subscription-" + _suffix;
+  private static final String topicId = "subscriber-test-topic-" + _suffix;
+  private static final String subscriptionId = "subscriber-test-subscription-" + _suffix;
   private static final TopicName topicName = TopicName.of(projectId, topicId);
   private static final ProjectSubscriptionName subscriptionName =
       ProjectSubscriptionName.of(projectId, subscriptionId);


### PR DESCRIPTION
Migrate admin and IAM samples, currently living in [`google-cloud-java`](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-examples/src/main/java/com/google/cloud/examples/pubsub/snippets) (no tests were written for them) and [`java-docs-samples`](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/master/pubsub/cloud-client) (incomplete set of samples).  This is **part 2 of 5** of Pub/Sub Java samples migration. 

Added tests for them too.  

Part 1: migrate publisher samples (#227 )
Part 2: migrate subscriber samples (#238 )
 **-> Part 3: migrate topic and subscription admin, iam samples**
Part 4: migrate emulator and other miscellaneous samples
Part 5: update docs. add notes to old samples. 