### PR TITLE
samples: update synth.py to exclude samples.yaml

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -522,4 +522,6 @@ for version in versions:
     java.format_code(f'grpc-google-cloud-{service}-{version}/src')
     java.format_code(f'proto-google-cloud-{service}-{version}/src')
 
-java.common_templates()
+java.common_templates(excludes=[
+  ".github/workflows/samples.yaml",
+])


### PR DESCRIPTION
This is to prevent synth from proposing PRs like #533. The synth-proposed change will cause the samples checkstyle test to miss this file https://github.com/googleapis/java-pubsub/blob/master/samples/checkstyle-suppressions.xml and therefore fail the checkstyle test. 

The checkstyle exclusions are for classes generated by Avro tools and protoc. They don't comply to the strict checkstyle rules.

- https://github.com/googleapis/java-pubsub/blob/master/samples/snippets/src/main/java/utilities/State.java
- https://github.com/googleapis/java-pubsub/blob/master/samples/snippets/src/main/java/utilities/StateProto.java