### PR TITLE
fix: update MessageDispatcher to not extend deadlines of messages which arrive early to 60s

### DIFF
--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/MessageDispatcher.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/MessageDispatcher.java
@@ -85,7 +85,7 @@ class MessageDispatcher {
   // Start the deadline at the minimum ack deadline so messages which arrive before this is
   // updated will not have a long ack deadline.
   private final AtomicInteger messageDeadlineSeconds = new AtomicInteger(
-      Subscriber.MIN_ACK_DEADLINE_SECONDS);
+    Subscriber.MIN_ACK_DEADLINE_SECONDS);
   private final AtomicBoolean extendDeadline = new AtomicBoolean(true);
   private final Lock jobLock;
   private ScheduledFuture<?> backgroundJob;

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/MessageDispatcher.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/MessageDispatcher.java
@@ -82,9 +82,10 @@ class MessageDispatcher {
   private final LinkedBlockingQueue<String> pendingNacks = new LinkedBlockingQueue<>();
   private final LinkedBlockingQueue<String> pendingReceipts = new LinkedBlockingQueue<>();
 
-  // The deadline should be set before use. Here, set it to something unreasonable,
-  // so we fail loudly if we mess up.
-  private final AtomicInteger messageDeadlineSeconds = new AtomicInteger(60);
+  // Start the deadline at the minimum ack deadline so messages which arrive before this is
+  // updated will not have a long ack deadline.
+  private final AtomicInteger messageDeadlineSeconds = new AtomicInteger(
+      Subscriber.MIN_ACK_DEADLINE_SECONDS);
   private final AtomicBoolean extendDeadline = new AtomicBoolean(true);
   private final Lock jobLock;
   private ScheduledFuture<?> backgroundJob;

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/MessageDispatcher.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/MessageDispatcher.java
@@ -84,8 +84,8 @@ class MessageDispatcher {
 
   // Start the deadline at the minimum ack deadline so messages which arrive before this is
   // updated will not have a long ack deadline.
-  private final AtomicInteger messageDeadlineSeconds = new AtomicInteger(
-    Subscriber.MIN_ACK_DEADLINE_SECONDS);
+  private final AtomicInteger messageDeadlineSeconds =
+      new AtomicInteger(Subscriber.MIN_ACK_DEADLINE_SECONDS);
   private final AtomicBoolean extendDeadline = new AtomicBoolean(true);
   private final Lock jobLock;
   private ScheduledFuture<?> backgroundJob;

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Subscriber.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Subscriber.java
@@ -184,9 +184,9 @@ public class Subscriber extends AbstractApiService implements SubscriberInterfac
     streamingSubscriberConnections = new ArrayList<StreamingSubscriberConnection>(numPullers);
 
     // We regularly look up the distribution for a good subscription deadline.
-    // So we seed the distribution with something reasonable to start with.
+    // So we seed the distribution with the minimum value to start with.
     // Distribution is percentile-based, so this value will eventually lose importance.
-    ackLatencyDistribution.record(60);
+    ackLatencyDistribution.record(MIN_ACK_DEADLINE_SECONDS);
   }
 
   /**


### PR DESCRIPTION
It looks like we had 60 second deadline extensions in the client before we attempt to update this property, on the premise that it would be updated inline. Due to code drift, this is no longer true, so I changed it to 10s (the min value) by default instead for messages which arrive before the first recalculation cycle.