### PR TITLE
test: presubmit against Lite samples

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -17,6 +17,7 @@ branchProtectionRules:
       - units (8)
       - units (11)
       - 'Kokoro - Test: Integration'
+      - 'Kokoro - Against Pub/Sub Lite samples'
       - cla/google
   - pattern: 1.111.0-sp
     isAdminEnforced: true
@@ -33,6 +34,7 @@ branchProtectionRules:
       - units (8)
       - units (11)
       - 'Kokoro - Test: Integration'
+      - 'Kokoro - Against Pub/Sub Lite samples'
       - cla/google
 permissionRules:
   - team: yoshi-admins

--- a/.kokoro/presubmit/presubmit-against-pubsublite-samples.cfg
+++ b/.kokoro/presubmit/presubmit-against-pubsublite-samples.cfg
@@ -1,0 +1,38 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/java11"
+}
+
+env_vars: {
+  key: "JOB_TYPE"
+  value: "presubmit-against-pubsublite-samples"
+}
+
+# TODO: remove this after we've migrated all tests and scripts
+env_vars: {
+  key: "GCLOUD_PROJECT"
+  value: "java-docs-samples-testing"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT"
+  value: "java-docs-samples-testing"
+}
+
+env_vars: {
+  key: "GOOGLE_CLOUD_PROJECT_NUMBER"
+  value: "779844219229"
+}
+
+env_vars: {
+  key: "GOOGLE_APPLICATION_CREDENTIALS"
+  value: "secret_manager/java-docs-samples-service-account"
+}
+
+env_vars: {
+  key: "SECRET_MANAGER_KEYS"
+  value: "java-docs-samples-service-account"
+}

--- a/synth.py
+++ b/synth.py
@@ -524,4 +524,6 @@ for version in versions:
 
 java.common_templates(excludes=[
   ".github/workflows/samples.yaml",
+  ".kokoro/build.sh",
+  ".github/sync-repo-settings.yaml",
 ])


### PR DESCRIPTION
Add a presubmit test to run against samples in https://github.com/googleapis/java-pubsublite.

This is to prevent future development here from breaking `java-pubsublite` unknowingly, which has happened before for `python-pubsub==2.4.0`. See https://pypi.org/project/google-cloud-pubsub/#history

~Need to wait for~ internal cl/378963191 ~to merge first.~ submitted.

--- 
This samples tests should correctly use the local/snapshot artifact instead of the remote one because `mvn clean install` runs before any samples tests.

"Downloading in Maven is triggered by a project declaring a dependency that is not present in the local repository": https://maven.apache.org/guides/introduction/introduction-to-repositories.html#downloading-from-a-remote-repository