### PR TITLE
samples: use LinkedHashMap for ordered publish

### DIFF
--- a/samples/snippets/src/main/java/pubsub/PublishWithOrderingKeys.java
+++ b/samples/snippets/src/main/java/pubsub/PublishWithOrderingKeys.java
@@ -27,7 +27,7 @@ import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.TopicName;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -54,7 +54,7 @@ public class PublishWithOrderingKeys {
             .build();
 
     try {
-      Map<String, String> messages = new HashMap<String, String>();
+      Map<String, String> messages = new LinkedHashMap<String, String>();
       messages.put("message1", "key1");
       messages.put("message2", "key2");
       messages.put("message3", "key1");

--- a/samples/snippets/src/main/java/pubsub/ResumePublishWithOrderingKeys.java
+++ b/samples/snippets/src/main/java/pubsub/ResumePublishWithOrderingKeys.java
@@ -27,7 +27,7 @@ import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.TopicName;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -52,7 +52,7 @@ public class ResumePublishWithOrderingKeys {
             .build();
 
     try {
-      Map<String, String> messages = new HashMap<String, String>();
+      Map<String, String> messages = new LinkedHashMap<String, String>();
       messages.put("message1", "key1");
       messages.put("message2", "key2");
       messages.put("message3", "key1");


### PR DESCRIPTION
A `LinkedHashMap` will ensure that messages are processed in order with no ambiguity. 

Samples Snapshot may fail due to recent removal of `SubscriptionPath`. It should be fixed when #907 is reversed.