### PR TITLE
samples: exit early if no messages are returned

### DIFF
--- a/samples/snippets/src/main/java/pubsub/SubscribeSyncExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeSyncExample.java
@@ -61,10 +61,10 @@ public class SubscribeSyncExample {
       // Use pullCallable().futureCall to asynchronously perform this operation.
       PullResponse pullResponse = subscriber.pullCallable().call(pullRequest);
 
-      // Exit the program if the pull response is empty.
+      // Discontinue the program if the pull response is empty.
       if (pullResponse.getReceivedMessagesList().isEmpty()) {
         System.out.println("No message was pulled. Exiting.");
-        System.exit(0);
+        return;
       }
 
       List<String> ackIds = new ArrayList<>();

--- a/samples/snippets/src/main/java/pubsub/SubscribeSyncExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeSyncExample.java
@@ -60,12 +60,20 @@ public class SubscribeSyncExample {
 
       // Use pullCallable().futureCall to asynchronously perform this operation.
       PullResponse pullResponse = subscriber.pullCallable().call(pullRequest);
+
+      // Exit the program if the pull response is empty.
+      if (pullResponse.getReceivedMessagesList().isEmpty()) {
+        System.out.println("No message was pulled. Exiting.");
+        System.exit(0);
+      }
+
       List<String> ackIds = new ArrayList<>();
       for (ReceivedMessage message : pullResponse.getReceivedMessagesList()) {
         // Handle received message
         // ...
         ackIds.add(message.getAckId());
       }
+
       // Acknowledge received messages.
       AcknowledgeRequest acknowledgeRequest =
           AcknowledgeRequest.newBuilder()

--- a/samples/snippets/src/main/java/pubsub/SubscribeSyncExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeSyncExample.java
@@ -61,7 +61,8 @@ public class SubscribeSyncExample {
       // Use pullCallable().futureCall to asynchronously perform this operation.
       PullResponse pullResponse = subscriber.pullCallable().call(pullRequest);
 
-      // Discontinue the program if the pull response is empty.
+      // Stop the program if the pull response is empty to avoid acknowledging
+      // an empty list of ack IDs.
       if (pullResponse.getReceivedMessagesList().isEmpty()) {
         System.out.println("No message was pulled. Exiting.");
         return;

--- a/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
@@ -38,9 +38,6 @@ public class SubscribeSyncWithLeaseExample {
     String subscriptionId = "your-subscription-id";
     Integer numOfMessages = 10;
 
-    projectId = "tz-playground-bigdata";
-    subscriptionId = "uno";
-
     subscribeSyncWithLeaseExample(projectId, subscriptionId, numOfMessages);
   }
 
@@ -68,8 +65,13 @@ public class SubscribeSyncWithLeaseExample {
       // Use pullCallable().futureCall to asynchronously perform this operation.
       PullResponse pullResponse = subscriber.pullCallable().call(pullRequest);
 
-      List<String> ackIds = new ArrayList<>();
+      // Exit the program if the pull response is empty.
+      if (pullResponse.getReceivedMessagesList().isEmpty()) {
+        System.out.println("No message was pulled. Exiting.");
+        System.exit(0);
+      }
 
+      List<String> ackIds = new ArrayList<>();
       for (ReceivedMessage message : pullResponse.getReceivedMessagesList()) {
         ackIds.add(message.getAckId());
 

--- a/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
@@ -65,7 +65,8 @@ public class SubscribeSyncWithLeaseExample {
       // Use pullCallable().futureCall to asynchronously perform this operation.
       PullResponse pullResponse = subscriber.pullCallable().call(pullRequest);
 
-      // Discontinue the program if the pull response is empty.
+      // Stop the program if the pull response is empty to avoid acknowledging
+      // an empty list of ack IDs.
       if (pullResponse.getReceivedMessagesList().isEmpty()) {
         System.out.println("No message was pulled. Exiting.");
         return;

--- a/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeSyncWithLeaseExample.java
@@ -65,10 +65,10 @@ public class SubscribeSyncWithLeaseExample {
       // Use pullCallable().futureCall to asynchronously perform this operation.
       PullResponse pullResponse = subscriber.pullCallable().call(pullRequest);
 
-      // Exit the program if the pull response is empty.
+      // Discontinue the program if the pull response is empty.
       if (pullResponse.getReceivedMessagesList().isEmpty()) {
         System.out.println("No message was pulled. Exiting.");
-        System.exit(0);
+        return;
       }
 
       List<String> ackIds = new ArrayList<>();


### PR DESCRIPTION
Fixes #189 

The current samples will fail with `io.grpc.StatusRuntimeException: INVALID_ARGUMENT: You have not specified an ack ID in the request` if no messages are returned. Updating them to handle this case. 

This does not affect the existing tests for the samples.

I also noticed something that should not have been published with one of the samples in the first place - my project and topic ID. Apologies.