### PR TITLE
samples: DEFAULT_REQUEST_BYTES_THRESHOLD default

### DIFF
--- a/samples/snippets/src/main/java/pubsub/PublishWithBatchSettingsExample.java
+++ b/samples/snippets/src/main/java/pubsub/PublishWithBatchSettingsExample.java
@@ -49,7 +49,7 @@ public class PublishWithBatchSettingsExample {
 
     try {
       // Batch settings control how the publisher batches messages
-      long requestBytesThreshold = 5000L; // default : 1000 byte
+      long requestBytesThreshold = 5000L; // default : 1000 bytes
       long messageCountBatchSize = 100L; // default : 100 message
 
       Duration publishDelayThreshold = Duration.ofMillis(100); // default : 1 ms

--- a/samples/snippets/src/main/java/pubsub/PublishWithBatchSettingsExample.java
+++ b/samples/snippets/src/main/java/pubsub/PublishWithBatchSettingsExample.java
@@ -49,8 +49,8 @@ public class PublishWithBatchSettingsExample {
 
     try {
       // Batch settings control how the publisher batches messages
-      long requestBytesThreshold = 5000L; // default : 1 byte
-      long messageCountBatchSize = 100L; // default : 1 message
+      long requestBytesThreshold = 5000L; // default : 1000 byte
+      long messageCountBatchSize = 100L; // default : 100 message
 
       Duration publishDelayThreshold = Duration.ofMillis(100); // default : 1 ms
 


### PR DESCRIPTION
Matching defaults in sample comments with real defaults in the client library. 

https://github.com/googleapis/java-pubsub/blob/3709b2eb842ac014203680c1af5b081c7a952e2f/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java#L657-L659

https://github.com/googleapis/java-pubsub/blob/3709b2eb842ac014203680c1af5b081c7a952e2f/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java#L666-L674