### PR TITLE
docs(sample): use Java 8 for native image sample

### DIFF
--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -20,8 +20,8 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
 
   <properties>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
The native image sample is failing during the nightly build with the following error:

```
ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] javac: invalid target release: 11
Usage: javac <options> <source files>
use -help for a list of possible options
```

This is because the Kokoro job uses Java 8. Setting the compiler Java version of the sample to Java 8 should be able to address this issue. 