### PR TITLE
fix: removed ordering beta api tag

### DIFF
--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
@@ -317,7 +317,6 @@ public class Publisher implements PublisherInterface {
    *
    * @param key The key for which to resume publishing.
    */
-  @BetaApi("Ordering is not yet fully supported and requires special project enablements.")
   public void resumePublish(String key) {
     Preconditions.checkState(!shutdown.get(), "Cannot publish on a shut-down publisher.");
     sequentialExecutor.resumePublish(key);
@@ -800,7 +799,6 @@ public class Publisher implements PublisherInterface {
     }
 
     /** Sets the message ordering option. */
-    @BetaApi("Ordering is not yet fully supported and requires special project enablements.")
     public Builder setEnableMessageOrdering(boolean enableMessageOrdering) {
       this.enableMessageOrdering = enableMessageOrdering;
       return this;


### PR DESCRIPTION
Removed @BetaApi decorator for ordering keys from publisher

Fixes #1048