### PR TITLE
fix: removed beta api annotation for ordering keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ implementation 'com.google.cloud:google-cloud-pubsub'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsub:1.116.3'
+implementation 'com.google.cloud:google-cloud-pubsub:1.116.4'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsub" % "1.116.3"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsub" % "1.116.4"
 ```
 
 ## Authentication

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
@@ -317,7 +317,6 @@ public class Publisher implements PublisherInterface {
    *
    * @param key The key for which to resume publishing.
    */
-  @BetaApi("Ordering is not yet fully supported and requires special project enablements.")
   public void resumePublish(String key) {
     Preconditions.checkState(!shutdown.get(), "Cannot publish on a shut-down publisher.");
     sequentialExecutor.resumePublish(key);
@@ -800,7 +799,6 @@ public class Publisher implements PublisherInterface {
     }
 
     /** Sets the message ordering option. */
-    @BetaApi("Ordering is not yet fully supported and requires special project enablements.")
     public Builder setEnableMessageOrdering(boolean enableMessageOrdering) {
       this.enableMessageOrdering = enableMessageOrdering;
       return this;


### PR DESCRIPTION
Removed `BetaApi` annotation for ordering keys.

Fixes #1093  ☕️

