### PR TITLE
deps: error_prone_annotations from the shared deps BOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:25.1.0')
+implementation platform('com.google.cloud:libraries-bom:25.2.0')
 
 implementation 'com.google.cloud:google-cloud-pubsub'
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -82,12 +82,6 @@
         <version>1.116.5-SNAPSHOT</version><!-- {x-version-update:google-cloud-pubsub:current} -->
       </dependency>
 
-      <dependency>
-        <groupId>com.google.errorprone</groupId>
-        <artifactId>error_prone_annotations</artifactId>
-        <version>2.13.1</version>
-      </dependency>
-
       <!-- Test dependencies -->
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
The shared dependencies BOM has error_prone_annotations entry. Let's use it rather than declaring the version here.