### PR TITLE
fix: modack batching fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,11 +13,11 @@
 # limitations under the License.
 # Github action job to test core java library features on
 # downstream client libraries before they are released.
-'on':
+on:
   push:
     branches:
-      - 1.117.x
-  pull_request: null
+    - main
+  pull_request:
 name: ci
 jobs:
   units:
@@ -25,69 +25,63 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java:
-          - 8
-          - 11
-          - 17
+        java: [8, 11, 17]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          distribution: zulu
-          java-version: ${{matrix.java}}
-      - run: java -version
-      - run: .kokoro/build.sh
-        env:
-          JOB_TYPE: test
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: ${{matrix.java}}
+    - run: java -version
+    - run: .kokoro/build.sh
+      env:
+        JOB_TYPE: test
   windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          distribution: zulu
-          java-version: 8
-      - run: java -version
-      - run: .kokoro/build.bat
-        env:
-          JOB_TYPE: test
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: 8
+    - run: java -version
+    - run: .kokoro/build.bat
+      env:
+        JOB_TYPE: test
   dependencies:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java:
-          - 8
-          - 11
-          - 17
+        java: [8, 11, 17]
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          distribution: zulu
-          java-version: ${{matrix.java}}
-      - run: java -version
-      - run: .kokoro/dependencies.sh
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: ${{matrix.java}}
+    - run: java -version
+    - run: .kokoro/dependencies.sh
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          distribution: zulu
-          java-version: 11
-      - run: java -version
-      - run: .kokoro/build.sh
-        env:
-          JOB_TYPE: lint
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: 11
+    - run: java -version
+    - run: .kokoro/build.sh
+      env:
+        JOB_TYPE: lint
   clirr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          distribution: zulu
-          java-version: 8
-      - run: java -version
-      - run: .kokoro/build.sh
-        env:
-          JOB_TYPE: clirr
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: zulu
+        java-version: 8
+    - run: java -version
+    - run: .kokoro/build.sh
+      env:
+        JOB_TYPE: clirr

--- a/README.md
+++ b/README.md
@@ -51,20 +51,20 @@ If you are using Maven without BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:25.2.0')
+implementation platform('com.google.cloud:libraries-bom:25.3.0')
 
 implementation 'com.google.cloud:google-cloud-pubsub'
 ```
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsub:1.116.4'
+implementation 'com.google.cloud:google-cloud-pubsub:1.117.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsub" % "1.116.4"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsub" % "1.117.0"
 ```
 
 ## Authentication

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/StreamingSubscriberConnection.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/StreamingSubscriberConnection.java
@@ -431,9 +431,9 @@ final class StreamingSubscriberConnection extends AbstractApiService implements 
     // Send modacks
     int pendingOperations = 0;
     for (ModackRequestData modackRequestData : modackRequestDataList) {
-      List<String> ackIdsInRequest = new ArrayList<>();
       for (List<AckRequestData> ackRequestDataInRequestList :
           Lists.partition(modackRequestData.getAckRequestData(), MAX_PER_REQUEST_CHANGES)) {
+        List<String> ackIdsInRequest = new ArrayList<>();
         for (AckRequestData ackRequestData : ackRequestDataInRequestList) {
           ackIdsInRequest.add(ackRequestData.getAckId());
           if (ackRequestData.hasMessageFuture()) {
@@ -511,9 +511,10 @@ final class StreamingSubscriberConnection extends AbstractApiService implements 
         // Remove from our pending operations
         ackOperationsWaiter.incrementPendingCount(-1);
 
+        Level level = isAlive() ? Level.WARNING : Level.FINER;
+        logger.log(level, "failed to send operations", t);
+
         if (!getExactlyOnceDeliveryEnabled()) {
-          Level level = isAlive() ? Level.WARNING : Level.FINER;
-          logger.log(level, "failed to send operations", t);
           return;
         }
 
@@ -578,9 +579,6 @@ final class StreamingSubscriberConnection extends AbstractApiService implements 
               currentBackoffMillis,
               TimeUnit.MILLISECONDS);
         }
-
-        Level level = isAlive() ? Level.WARNING : Level.FINER;
-        logger.log(level, "failed to send operations", t);
       }
     };
   }


### PR DESCRIPTION
Modack batching fix for LTS 1.117,x

* Moved the `ackIdsInRequest` for modack operations to the correct place. 
* Wrote tests around expected batching/partition behavior to verify change works as expected

Fixes #1126 which was due to incorrect partitioning of `ackIds` for `ModifyAckDeadlineRequest`