### PR TITLE
docs(sample): remove no-server build arg

### DIFF
--- a/samples/native-image-sample/pom.xml
+++ b/samples/native-image-sample/pom.xml
@@ -141,7 +141,6 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
               </mainClass>
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
-                <buildArg>--no-server</buildArg>
               </buildArgs>
             </configuration>
             <executions>


### PR DESCRIPTION
Proposing this change since no-server is now [enabled by default](https://github.com/oracle/graal/issues/2598), and I got a warning that this flag is being ignored during the build.

For context, I got the warning when building on cloud shell with Graal 22.0.0.2-r17.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
