### PR TITLE
fix: updating return types of ack/nack futures to be consistent with publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ implementation 'com.google.cloud:google-cloud-pubsub'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsub:1.120.2'
+implementation 'com.google.cloud:google-cloud-pubsub:1.120.3'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsub" % "1.120.2"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsub" % "1.120.3"
 ```
 
 ## Authentication

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ implementation 'com.google.cloud:google-cloud-pubsub'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsub:1.120.3'
+implementation 'com.google.cloud:google-cloud-pubsub:1.120.2'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsub" % "1.120.3"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsub" % "1.120.2"
 ```
 
 ## Authentication

--- a/google-cloud-pubsub/clirr-ignored-differences.xml
+++ b/google-cloud-pubsub/clirr-ignored-differences.xml
@@ -17,4 +17,21 @@
     <className>com/google/cloud/pubsub/v1/MessageDispatcher$Builder</className>
     <method>com.google.cloud.pubsub.v1.MessageDispatcher$Builder setEnableExactlyOnceDelivery(boolean)</method>
   </difference>
+
+  <difference>
+    <!-- This should be removed after the next release 1.121.x -->
+    <differenceType>7006</differenceType>
+    <className>com/google/cloud/pubsub/v1/AckReplyConsumerWithResponse</className>
+    <method>*ack()</method>
+    <to>com.google.api.core.ApiFuture</to>
+    <justification>Updating return types to be consistent with Publish</justification>
+  </difference>
+  <difference>
+    <!-- This should be removed after the next release 1.121.x -->
+    <differenceType>7006</differenceType>
+    <className>com/google/cloud/pubsub/v1/AckReplyConsumerWithResponseImpl</className>
+    <method>*ack()</method>
+    <to>com.google.api.core.ApiFuture</to>
+    <justification>Updating return types to be consistent with Publish</justification>
+  </difference>
 </differences>

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/AckReplyConsumerWithResponse.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/AckReplyConsumerWithResponse.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.pubsub.v1;
 
+import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
-import java.util.concurrent.Future;
 
 /**
  * Acknowledging a message in Pub/Sub means that you are done with it, and it will not be delivered
@@ -42,7 +42,7 @@ public interface AckReplyConsumerWithResponse {
    *
    * <p>A future representing the server response is returned
    */
-  Future<AckResponse> ack();
+  ApiFuture<AckResponse> ack();
 
   /**
    * Signals that the message has not been successfully processed. The service should resend the
@@ -50,5 +50,5 @@ public interface AckReplyConsumerWithResponse {
    *
    * <p>A future representing the server response is returned
    */
-  Future<AckResponse> nack();
+  ApiFuture<AckResponse> nack();
 }

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/AckReplyConsumerWithResponseImpl.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/AckReplyConsumerWithResponseImpl.java
@@ -15,8 +15,8 @@
  */
 package com.google.cloud.pubsub.v1;
 
+import com.google.api.core.ApiFuture;
 import com.google.api.core.SettableApiFuture;
-import java.util.concurrent.Future;
 
 public class AckReplyConsumerWithResponseImpl implements AckReplyConsumerWithResponse {
   final SettableApiFuture<MessageDispatcher.AckReply> ackReplySettableApiFuture;
@@ -30,13 +30,13 @@ public class AckReplyConsumerWithResponseImpl implements AckReplyConsumerWithRes
   }
 
   @Override
-  public Future<AckResponse> ack() {
+  public ApiFuture<AckResponse> ack() {
     ackReplySettableApiFuture.set(MessageDispatcher.AckReply.ACK);
     return messageFuture;
   }
 
   @Override
-  public Future<AckResponse> nack() {
+  public ApiFuture<AckResponse> nack() {
     ackReplySettableApiFuture.set(MessageDispatcher.AckReply.NACK);
     return messageFuture;
   }


### PR DESCRIPTION
Updating the return types of the `AckReplyConsumerWithResponse` interface, as well as the implementation `AckReplyConsumerWithResponseImpl`, from `Future` to `ApiFuture`, in order to be consistent with the return type of `Publish.publish`.