### PR TITLE
chore: configure 1.117.x branch as java-backport

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -20,5 +20,5 @@ branches:
     branch: 1.116.x
   - bumpMinorPreMajor: true
     handleGHRelease: true
-    releaseType: java-lts
+    releaseType: java-backport
     branch: 1.117.x


### PR DESCRIPTION
https://github.com/googleapis/java-pubsub/pull/1343 shows "-sp.2" suffix as version. It's an old style "java-lts" configuration. 

The branch: "1.111.0-sp" is ok to continue to use the old style as the branch name suggests.