### PR TITLE
chore: restore missing native image configuration

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -69,6 +69,16 @@ integration)
       verify
     RETURN_CODE=$?
     ;;
+graalvm)
+    # Run Unit and Integration Tests with Native Image
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Penable-integration-tests test
+    RETURN_CODE=$?
+    ;;
+graalvm17)
+    # Run Unit and Integration Tests with Native Image
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Penable-integration-tests test
+    RETURN_CODE=$?
+    ;;
 samples)
     SAMPLES_DIR=samples
     # only run ITs in snapshot/ on presubmit PRs. run ITs in all 3 samples/ subdirectories otherwise.


### PR DESCRIPTION
Recently discovered that the build script changes were excluded from https://github.com/googleapis/java-pubsub/pull/878. Fortunately, these tests have been regularly tested to verify native image compatibility but the changes in this PR need to be merged to ensure that nothing slips through the cracks in the future. 
