### PR TITLE
fix: adding an explicit check to prevent empty publishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ implementation 'com.google.cloud:google-cloud-pubsub'
 If you are using Gradle without BOM, add this to your dependencies:
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-pubsub:1.120.22'
+implementation 'com.google.cloud:google-cloud-pubsub:1.120.23'
 ```
 
 If you are using SBT, add this to your dependencies:
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-pubsub" % "1.120.22"
+libraryDependencies += "com.google.cloud" % "google-cloud-pubsub" % "1.120.23"
 ```
 
 ## Authentication

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
@@ -462,6 +462,10 @@ public class Publisher implements PublisherInterface {
   }
 
   private void publishOutstandingBatch(final OutstandingBatch outstandingBatch) {
+    if (outstandingBatch.size() == 0) {
+      logger.log(Level.WARNING, "Attempted to publish batch with zero messages.");
+      return;
+    }
     final ApiFutureCallback<PublishResponse> futureCallback =
         new ApiFutureCallback<PublishResponse>() {
           @Override


### PR DESCRIPTION
Adding an explicit check to prevent a publish attempt with no messages.
