### PR TITLE
chore: skip opencensus-api enforcer rule (1.111.0-sp branch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,28 @@
             </ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.0.0-M3</version>
+          <executions>
+            <execution>
+              <id>enforce</id>
+              <configuration>
+                <rules>
+                  <requireUpperBoundDeps>
+                    <excludes>
+                      <exclude>io.opencensus:opencensus-api</exclude>
+                    </excludes>
+                  </requireUpperBoundDeps>
+                </rules>
+              </configuration>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
Fixes https://github.com/googleapis/java-pubsub/issues/1387, where the build failed:

```
[WARNING] Rule 2: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for io.opencensus:opencensus-api:0.24.0 paths to dependency are:
+-com.google.cloud:google-cloud-pubsub:1.111.0-sp.3
  +-io.opencensus:opencensus-api:0.24.0
and
+-com.google.cloud:google-cloud-pubsub:1.111.0-sp.3
  +-com.google.api:gax:1.60.1
    +-io.opencensus:opencensus-api:0.24.0 (managed) <-- io.opencensus:opencensus-api:0.28.0
and
+-com.google.cloud:google-cloud-pubsub:1.111.0-sp.3
  +-com.google.http-client:google-http-client:1.38.0
    +-io.opencensus:opencensus-api:0.24.0 (managed) <-- io.opencensus:opencensus-api:0.28.0
and
...
```