### PR TITLE
feat: Open telemetry message wrapper

### DIFF
--- a/google-cloud-pubsub/pom.xml
+++ b/google-cloud-pubsub/pom.xml
@@ -172,6 +172,12 @@
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.testparameterinjector</groupId>
+      <artifactId>test-parameter-injector</artifactId>
+      <version>1.10</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/google-cloud-pubsub/pom.xml
+++ b/google-cloud-pubsub/pom.xml
@@ -100,6 +100,11 @@
       <artifactId>google-http-client</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.20.0</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>
@@ -140,6 +145,12 @@
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk</artifactId>
+      <version>1.20.0</version>
       <scope>test</scope>
     </dependency>
     <!-- Need testing utility classes for generated gRPC clients tests -->

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
@@ -52,6 +52,8 @@ import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.TopicName;
 import com.google.pubsub.v1.TopicNames;
 import io.grpc.CallOptions;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.trace.Tracer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -92,6 +94,7 @@ public class Publisher implements PublisherInterface {
   private static final Logger logger = Logger.getLogger(Publisher.class.getName());
 
   private static final String GZIP_COMPRESSION = "gzip";
+  private static final String OPEN_TELEMETRY_TRACER_NAME = "cloud.google.com/java/pubsub";
 
   private final String topicName;
 
@@ -123,6 +126,9 @@ public class Publisher implements PublisherInterface {
 
   private final GrpcCallContext publishContext;
   private final GrpcCallContext publishContextWithCompression;
+
+  private OpenTelemetry openTelemetry;
+  private Tracer openTelemetryTracer;
 
   /** The maximum number of messages in one request. Defined by the API. */
   public static long getApiMaxRequestElementCount() {
@@ -207,6 +213,11 @@ public class Publisher implements PublisherInterface {
     this.publishContextWithCompression =
         GrpcCallContext.createDefault()
             .withCallOptions(CallOptions.DEFAULT.withCompression(GZIP_COMPRESSION));
+    this.openTelemetry = builder.openTelemetry;
+    if (this.openTelemetry != null) {
+      // Create a tracer if we have an instance of OpenTelemetry
+      this.openTelemetryTracer = this.openTelemetry.getTracer(OPEN_TELEMETRY_TRACER_NAME);
+    }
   }
 
   /** Topic which the publisher publishes to. */
@@ -747,6 +758,8 @@ public class Publisher implements PublisherInterface {
     private boolean enableCompression = DEFAULT_ENABLE_COMPRESSION;
     private long compressionBytesThreshold = DEFAULT_COMPRESSION_BYTES_THRESHOLD;
 
+    private OpenTelemetry openTelemetry;
+
     private Builder(String topic) {
       this.topicName = Preconditions.checkNotNull(topic);
     }
@@ -875,6 +888,12 @@ public class Publisher implements PublisherInterface {
     /** Returns the default BatchingSettings used by the client if settings are not provided. */
     public static BatchingSettings getDefaultBatchingSettings() {
       return DEFAULT_BATCHING_SETTINGS;
+    }
+
+    /** Sets the Open Telemetry Instance to allow for tracing. */
+    public Builder setOpenTelemetry(OpenTelemetry openTelemetry) {
+      this.openTelemetry = openTelemetry;
+      return this;
     }
 
     public Publisher build() throws IOException {

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/PubsubMessageWrapper.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/PubsubMessageWrapper.java
@@ -55,7 +55,7 @@ public class PubsubMessageWrapper {
 
   private String RECEIVE_SPAN_NAME;
   private static final String SUBSCRIBE_FLOW_CONTROL_SPAN_NAME = "subscribe flow control";
-  private static final String SUBSCRIBE_SCHEDULE_SPAN_NAME = "subscribe flow control";
+  private static final String SUBSCRIBE_SCHEDULE_SPAN_NAME = "subscribe scheduler";
   private static final String PROCESS = "process";
   private String PROCESS_SPAN_NAME;
   private static final String MODACK_SPAN_NAME = "send modifyAckDeadline";
@@ -154,7 +154,7 @@ public class PubsubMessageWrapper {
     Span parent =
         this.subscribeFlowControlSpan.isPresent()
             ? this.subscribeFlowControlSpan.get()
-            : this.publishSpan;
+            : this.subscribeSpan;
     this.subscribeSchedulerSpan =
         Optional.of(this.createAndStartSpan(tracer, SUBSCRIBE_SCHEDULE_SPAN_NAME, parent));
   }

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/PubsubMessageWrapper.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/PubsubMessageWrapper.java
@@ -16,64 +16,236 @@
 
 package com.google.cloud.pubsub.v1;
 
+import com.google.common.base.Preconditions;
 import com.google.pubsub.v1.PubsubMessage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
+import java.util.Optional;
 
 public class PubsubMessageWrapper {
-    private static final String MESSAGE_ATTRIBUTE_PREFIX = "googclient_";
-    // TODO: Update this to use the actual project + topic name
-    private static final String PUBLISH_SPAN_NAME = "projects/my-project/topics/my-topic send";
-    private static final String FLOW_CONTROL_SPAN_NAME = "publisher flow control";
-    private static final String PUBLISH_RPC_SPAN_NAME = "send Publish";
+  private final PubsubMessage pubsubMessage;
 
+  private static final String MESSAGE_ATTRIBUTE_PREFIX = "googclient_";
+
+  /**
+   * Publish Spans are hierarchical - they must be open and closed in the following order:
+   *
+   * <p>Publish -> (optional) Flow Control -> (optional) Scheduler -> PublishRpc
+   */
+  private static final String SEND = "send";
+
+  private String PUBLISH_SPAN_NAME;
+  private static final String PUBLISH_FLOW_CONTROL_SPAN_NAME = "publish flow control";
+  private static final String PUBLISH_SCHEDULER_SPAN_NAME = "publish scheduler";
+  private static final String PUBLISH_RPC_SPAN_NAME = "send Publish";
+
+  private Span publishSpan;
+  private Optional<Span> publishFlowControlSpan = Optional.empty();
+  private Optional<Span> publishSchedulerSpan = Optional.empty();
+  private Span publishRpcSpan;
+
+  /**
+   * Subscribe Spans are hierarchical - they must be open and closed in the following order:
+   *
+   * <p>Receive -> (optional) Flow Control -> (optional) Scheduler -> Process -> ModifyAckDeadline
+   * -> Acknowledgement OR Negative Acknowledgement
+   */
+  private static final String RECEIVE = "receive";
+
+  private String RECEIVE_SPAN_NAME;
+  private static final String SUBSCRIBE_FLOW_CONTROL_SPAN_NAME = "subscribe flow control";
+  private static final String SUBSCRIBE_SCHEDULE_SPAN_NAME = "subscribe flow control";
+  private static final String PROCESS = "process";
+  private String PROCESS_SPAN_NAME;
+  private static final String MODACK_SPAN_NAME = "send modifyAckDeadline";
+  private static final String ACK_SPAN_NAME = "send Acknowledgement";
+  private static final String NACK_SPAN_NAME = "send Negative Acknowledgement";
+
+  private Span subscribeSpan;
+  private Optional<Span> subscribeFlowControlSpan = Optional.empty();
+  private Optional<Span> subscribeSchedulerSpan = Optional.empty();
+  private Span processSpan;
+  private Span modackSpan;
+  private Span ackSpan;
+  private Span nackSpan;
+
+  protected PubsubMessageWrapper(Builder builder) {
+    this.pubsubMessage = builder.pubsubMessage;
+
+    if (builder.topicName.isPresent()) {
+      this.PUBLISH_SPAN_NAME = builder.topicName.get() + " " + this.SEND;
+    }
+
+    if (builder.subscriptionName.isPresent()) {
+      this.RECEIVE_SPAN_NAME = builder.subscriptionName.get() + " " + this.RECEIVE;
+      this.PROCESS_SPAN_NAME = builder.subscriptionName.get() + " " + this.PROCESS;
+    }
+  }
+
+  public void startPublishSpan(Tracer tracer) {
+    this.publishSpan = createAndStartSpan(tracer, PUBLISH_SPAN_NAME);
+  }
+
+  public void endPublishSpan() {
+    this.publishSpan.end();
+  }
+
+  /** (Optional) Start Publish Flow Control Span */
+  public void startPublishFlowControlSpan(Tracer tracer) {
+    this.publishFlowControlSpan =
+        Optional.of(createAndStartSpan(tracer, PUBLISH_FLOW_CONTROL_SPAN_NAME, this.publishSpan));
+  }
+
+  /** (Optional) End Publish Flow Control Span */
+  public void endPublishFlowControlSpan() {
+    if (this.publishFlowControlSpan.isPresent()) {
+      this.publishFlowControlSpan.get().end();
+    }
+  }
+
+  /** (Optional) Start Flow Control Span */
+  public void startPublishSchedulerSpan(Tracer tracer) {
+    // Check for optional parent
+    Span parent =
+        this.publishFlowControlSpan.isPresent()
+            ? this.publishFlowControlSpan.get()
+            : this.publishSpan;
+    this.publishSchedulerSpan =
+        Optional.of(this.createAndStartSpan(tracer, PUBLISH_SCHEDULER_SPAN_NAME, parent));
+  }
+
+  /** (Optional) End Publish Scheduler Span */
+  public void endPublishSchedulerSpan() {
+    if (this.publishSchedulerSpan.isPresent()) {
+      this.publishSchedulerSpan.get().end();
+    }
+  }
+
+  public void startPublishRpcSpan(Tracer tracer) {
+    this.publishRpcSpan = createAndStartSpan(tracer, PUBLISH_RPC_SPAN_NAME, publishSpan);
+  }
+
+  public void endPublishRpcSpan() {
+    this.publishRpcSpan.end();
+  }
+
+  public void startSubscribeReceiveSpan(Tracer tracer) {
+    this.subscribeSpan = createAndStartSpan(tracer, RECEIVE_SPAN_NAME);
+  }
+
+  public void endSubscribeReceiveSpan() {
+    this.subscribeSpan.end();
+  }
+
+  public void startSubscribeFlowControlSpan(Tracer tracer) {
+    this.subscribeFlowControlSpan =
+        Optional.of(
+            this.createAndStartSpan(tracer, SUBSCRIBE_FLOW_CONTROL_SPAN_NAME, this.subscribeSpan));
+  }
+
+  public void endSubscribeFlowControlSpan() {
+    if (this.subscribeFlowControlSpan.isPresent()) {
+      this.subscribeFlowControlSpan.get().end();
+    }
+  }
+
+  public void startSubscribeSchedulerSpan(Tracer tracer) {
+    Span parent =
+        this.subscribeFlowControlSpan.isPresent()
+            ? this.subscribeFlowControlSpan.get()
+            : this.publishSpan;
+    this.subscribeSchedulerSpan =
+        Optional.of(this.createAndStartSpan(tracer, SUBSCRIBE_SCHEDULE_SPAN_NAME, parent));
+  }
+
+  public void endSubscribeSchedulerSpan() {
+    if (this.subscribeSchedulerSpan.isPresent()) {
+      this.subscribeSchedulerSpan.get().end();
+    }
+  }
+
+  public void startSubscribeProcessSpan(Tracer tracer) {
+    Span parent = this.subscribeSpan;
+
+    // Check for optional Scheduler and Flow Control spans
+    if (this.subscribeSchedulerSpan.isPresent()) {
+      parent = this.subscribeSchedulerSpan.get();
+    } else if (this.subscribeFlowControlSpan.isPresent()) {
+      parent = this.subscribeFlowControlSpan.get();
+    }
+
+    this.processSpan = this.createAndStartSpan(tracer, PROCESS_SPAN_NAME, parent);
+  }
+
+  public void endSubscribeProcessSpan() {
+    this.processSpan.end();
+  }
+
+  public void startSubscribeModAckSpan(Tracer tracer) {
+    this.modackSpan = this.createAndStartSpan(tracer, MODACK_SPAN_NAME, this.processSpan);
+  }
+
+  public void endSubscribeModAckSpan() {
+    this.modackSpan.end();
+  }
+
+  public void startSubscribeAckSpan(Tracer tracer) {
+    this.ackSpan = this.createAndStartSpan(tracer, ACK_SPAN_NAME, this.modackSpan);
+  }
+
+  public void endSubscribeAckSpan() {
+    this.ackSpan.end();
+  }
+
+  public void startSubscribeNackSpan(Tracer tracer) {
+    this.nackSpan = this.createAndStartSpan(tracer, NACK_SPAN_NAME, this.modackSpan);
+  }
+
+  public void endSubscribeNackSpan() {
+    this.nackSpan.end();
+  }
+
+  private Span createAndStartSpan(Tracer tracer, String spanName) {
+    return tracer.spanBuilder(spanName).startSpan();
+  }
+
+  private Span createAndStartSpan(Tracer tracer, String spanName, Span parent) {
+    return tracer.spanBuilder(spanName).setParent(Context.current().with(parent)).startSpan();
+  }
+
+  public static PubsubMessageWrapper.Builder newBuilder(PubsubMessage pubsubMessage) {
+    return new Builder(pubsubMessage);
+  }
+
+  /** Builder of {@link PubsubMessageWrapper PubsubMessageWrapper}. */
+  protected static final class Builder {
     private final PubsubMessage pubsubMessage;
-    private Span publishSpan;
-    private Span flowControlSpan;
-    private Span publishRpcSpan;
+    private Optional<String> topicName;
+    private Optional<String> subscriptionName;
 
-    protected PubsubMessageWrapper(PubsubMessage pubsubMessage) {
-        this.pubsubMessage = pubsubMessage;
+    protected Builder(PubsubMessage pubsubMessage) {
+      this.pubsubMessage = pubsubMessage;
+      this.topicName = Optional.empty();
+      this.subscriptionName = Optional.empty();
     }
 
-    public void startPublishSpan(Tracer tracer) {
-        this.publishSpan = createAndStartSpan(tracer, PUBLISH_SPAN_NAME);
+    /** Set the topic name to allow for publish span names */
+    public Builder setTopicName(String topicName) {
+      this.topicName = Optional.of(topicName);
+      return this;
     }
 
-    public void endPublishSpan() throws {
-        // TODO: Check that child spans are completed
-
-
-        this.publishSpan.end();
+    /** Set the subscription name to allow for subscribe span names */
+    public Builder setSubscriptionName(String subscriptionName) {
+      this.subscriptionName = Optional.of(subscriptionName);
+      return this;
     }
 
-    public void startPublishRpcSpan(Tracer tracer) {
-        this.publishRpcSpan = createAndStartSpan(tracer, PUBLISH_RPC_SPAN_NAME, publishSpan);
+    public PubsubMessageWrapper build() {
+      // Requires one of {topicName, subscriptionName}
+      Preconditions.checkArgument(this.topicName.isPresent() || this.subscriptionName.isPresent());
+      return new PubsubMessageWrapper(this);
     }
-
-    public void endPublishRpcSpan() {
-        this.publishRpcSpan.end();
-    }
-
-//    /** (Optional) Start Flow Control Span */
-//    public void startFlowControlSpan(Tracer tracer) {
-//
-//    }
-//
-//    /** (Optional) End Flow Control Span */
-//    public void endFlowControlSpan() {}
-
-    private Span createAndStartSpan(Tracer tracer, String spanName) {
-        return tracer.spanBuilder(PUBLISH_SPAN_NAME).startSpan();
-    }
-
-    private Span createAndStartSpan(Tracer tracer, String spanName, Span parent) {
-        return tracer.spanBuilder(PUBLISH_SPAN_NAME).setParent(Context.current().with(parent)).startSpan();
-    }
-
-    public abstract static class PubsubMessageWrapperException extends Exception {
-        private PubsubMessageWrapperException() {
-        }
-    }
+  }
 }

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/PubsubMessageWrapper.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/PubsubMessageWrapper.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsub.v1;
+
+import com.google.pubsub.v1.PubsubMessage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+
+public class PubsubMessageWrapper {
+    private static final String MESSAGE_ATTRIBUTE_PREFIX = "googclient_";
+    // TODO: Update this to use the actual project + topic name
+    private static final String PUBLISH_SPAN_NAME = "projects/my-project/topics/my-topic send";
+    private static final String FLOW_CONTROL_SPAN_NAME = "publisher flow control";
+    private static final String PUBLISH_RPC_SPAN_NAME = "send Publish";
+
+    private final PubsubMessage pubsubMessage;
+    private Span publishSpan;
+    private Span flowControlSpan;
+    private Span publishRpcSpan;
+
+    protected PubsubMessageWrapper(PubsubMessage pubsubMessage) {
+        this.pubsubMessage = pubsubMessage;
+    }
+
+    public void startPublishSpan(Tracer tracer) {
+        this.publishSpan = createAndStartSpan(tracer, PUBLISH_SPAN_NAME);
+    }
+
+    public void endPublishSpan() throws {
+        // TODO: Check that child spans are completed
+
+
+        this.publishSpan.end();
+    }
+
+    public void startPublishRpcSpan(Tracer tracer) {
+        this.publishRpcSpan = createAndStartSpan(tracer, PUBLISH_RPC_SPAN_NAME, publishSpan);
+    }
+
+    public void endPublishRpcSpan() {
+        this.publishRpcSpan.end();
+    }
+
+//    /** (Optional) Start Flow Control Span */
+//    public void startFlowControlSpan(Tracer tracer) {
+//
+//    }
+//
+//    /** (Optional) End Flow Control Span */
+//    public void endFlowControlSpan() {}
+
+    private Span createAndStartSpan(Tracer tracer, String spanName) {
+        return tracer.spanBuilder(PUBLISH_SPAN_NAME).startSpan();
+    }
+
+    private Span createAndStartSpan(Tracer tracer, String spanName, Span parent) {
+        return tracer.spanBuilder(PUBLISH_SPAN_NAME).setParent(Context.current().with(parent)).startSpan();
+    }
+
+    public abstract static class PubsubMessageWrapperException extends Exception {
+        private PubsubMessageWrapperException() {
+        }
+    }
+}

--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PubsubMessageWrapperTest.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PubsubMessageWrapperTest.java
@@ -21,58 +21,155 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
-import org.junit.Before;
+import io.opentelemetry.context.Context;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 
 public class PubsubMessageWrapperTest {
-    @Rule public TestName testName = new TestName();
+  @Rule public TestName testName = new TestName();
 
-    private static final String PUBLISH_SPAN_NAME = "projects/my-project/topics/my-topic send";
-    private static final String FLOW_CONTROL_SPAN_NAME = "publisher flow control";
-    private static final String PUBLISH_RPC_SPAN_NAME = "send Publish";
+  private static final String FULL_TOPIC_NAME = "projects/my-project/topics/my-topic";
+  private static final String PUBLISH_SPAN_NAME = "projects/my-project/topics/my-topic send";
+  private static final String PUBLISH_FLOW_CONTROL_SPAN_NAME = "publish flow control";
+  private static final String PUBLISH_SCHEDULER_SPAN_NAME = "publish scheduler";
+  private static final String PUBLISH_RPC_SPAN_NAME = "send Publish";
 
-    private Tracer mockTracer;
-    private Span mockPublishSpan;
-    private Span mockPublishRpcSpan;
+  private static final String FULL_SUBSCRIPTION_NAME = "projects/my-project/subscriptions/my-sub";
+  private static final String RECEIVE_SPAN_NAME =
+      "projects/my-project/subscriptions/my-sub receive";
+  private static final String SUBSCRIBE_PROCESS_SPAN_NAME =
+      "projects/my-project/subscriptions/my-sub process";
+  private static final String MODACK_SPAN_NAME = "send modifyAckDeadline";
+  private static final String ACK_SPAN_NAME = "send Acknowledgement";
+  private static final String NACK_SPAN_NAME = "send Negative Acknowledgement";
 
-    @Before
-    public void setUp() {
-        // Setting up our mocks for consistency
-        this.mockTracer = mock(Tracer.class, RETURNS_DEEP_STUBS);
-        this.mockPublishSpan = mock(Span.class);
-        this.mockPublishRpcSpan = mock(Span.class);
+  @Test
+  public void testPublishSpans() {
+    Tracer mockTracer = mock(Tracer.class, RETURNS_DEEP_STUBS);
+
+    Span mockPublishSpan = mock(Span.class);
+    Span mockPublishFlowControlSpan = mock(Span.class);
+    Span mockPublishSchedulerSpan = mock(Span.class);
+    Span mockPublishRpcSpan = mock(Span.class);
+
+    PubsubMessageWrapper pubsubMessageWrapper =
+        PubsubMessageWrapper.newBuilder(getPubsubMessage()).setTopicName(FULL_TOPIC_NAME).build();
+
+    when(mockTracer.spanBuilder(PUBLISH_SPAN_NAME).startSpan()).thenReturn(mockPublishSpan);
+    when(mockTracer
+            .spanBuilder(PUBLISH_FLOW_CONTROL_SPAN_NAME)
+            .setParent(Context.current().with(mockPublishSpan))
+            .startSpan())
+        .thenReturn(mockPublishFlowControlSpan);
+    when(mockTracer
+            .spanBuilder(PUBLISH_SCHEDULER_SPAN_NAME)
+            .setParent(Context.current().with(mockPublishFlowControlSpan))
+            .startSpan())
+        .thenReturn(mockPublishSchedulerSpan);
+    when(mockTracer
+            .spanBuilder(PUBLISH_RPC_SPAN_NAME)
+            .setParent(Context.current().with(mockPublishSchedulerSpan))
+            .startSpan())
+        .thenReturn(mockPublishRpcSpan);
+
+    pubsubMessageWrapper.startPublishSpan(mockTracer);
+    pubsubMessageWrapper.startPublishFlowControlSpan(mockTracer);
+    pubsubMessageWrapper.startPublishSchedulerSpan(mockTracer);
+    pubsubMessageWrapper.startPublishRpcSpan(mockTracer);
+
+    pubsubMessageWrapper.endPublishRpcSpan();
+    pubsubMessageWrapper.endPublishSchedulerSpan();
+    pubsubMessageWrapper.endPublishFlowControlSpan();
+    pubsubMessageWrapper.endPublishSpan();
+
+    verify(mockPublishSpan, times(1)).end();
+    verify(mockPublishFlowControlSpan, times(1)).end();
+    verify(mockPublishSchedulerSpan, times(1)).end();
+    verify(mockPublishRpcSpan, times(1)).end();
+  }
+
+  @Test
+  public void testSubscribeSpans() {
+    testSubscribeSpan(true);
+    testSubscribeSpan(false);
+  }
+
+  private void testSubscribeSpan(boolean isAck) {
+    Tracer mockTracer = mock(Tracer.class, RETURNS_DEEP_STUBS);
+
+    PubsubMessageWrapper pubsubMessageWrapper =
+        PubsubMessageWrapper.newBuilder(getPubsubMessage())
+            .setSubscriptionName(FULL_SUBSCRIPTION_NAME)
+            .build();
+
+    Span mockReceiveSpan = mock(Span.class);
+    Span mockSchedulerSpan = mock(Span.class);
+    Span mockFlowControlSpan = mock(Span.class);
+    Span mockProcessSpan = mock(Span.class);
+    Span mockModackSpan = mock(Span.class);
+    Span mockAckNackSpan = mock(Span.class);
+
+    when(mockTracer.spanBuilder(RECEIVE_SPAN_NAME).startSpan()).thenReturn(mockReceiveSpan);
+    when(mockTracer
+            .spanBuilder(SUBSCRIBE_PROCESS_SPAN_NAME)
+            .setParent(Context.current().with(mockReceiveSpan))
+            .startSpan())
+        .thenReturn(mockProcessSpan);
+
+    when(mockTracer
+            .spanBuilder(MODACK_SPAN_NAME)
+            .setParent(Context.current().with(mockProcessSpan))
+            .startSpan())
+        .thenReturn(mockModackSpan);
+
+    if (isAck) {
+      when(mockTracer
+              .spanBuilder(ACK_SPAN_NAME)
+              .setParent(Context.current().with(mockModackSpan))
+              .startSpan())
+          .thenReturn(mockAckNackSpan);
+    } else {
+      when(mockTracer
+              .spanBuilder(NACK_SPAN_NAME)
+              .setParent(Context.current().with(mockModackSpan))
+              .startSpan())
+          .thenReturn(mockAckNackSpan);
     }
 
-    @Test
-    public void testRequiredSpans() {
-        PubsubMessageWrapper pubsubMessageWrapper = new PubsubMessageWrapper(getPubsubMessage());
+    pubsubMessageWrapper.startSubscribeReceiveSpan(mockTracer);
+    //    pubsubMessageWrapper.startSubscribeFlowControlSpan(mockTracer);
+    //    pubsubMessageWrapper.startSubscribeSchedulerSpan(mockTracer);
+    pubsubMessageWrapper.startSubscribeProcessSpan(mockTracer);
+    pubsubMessageWrapper.startSubscribeModAckSpan(mockTracer);
 
-        when(this.mockTracer.spanBuilder(PUBLISH_SPAN_NAME).startSpan()).thenReturn(this.mockPublishSpan);
-        when(this.mockTracer.spanBuilder(PUBLISH_RPC_SPAN_NAME).startSpan()).thenReturn(this.mockPublishSpan);
-
-        pubsubMessageWrapper.startPublishSpan(this.mockTracer);
-        pubsubMessageWrapper.startPublishRpcSpan(this.mockTracer);
-        pubsubMessageWrapper.endPublishRpcSpan();
-        pubsubMessageWrapper.endPublishSpan();
-
-        verify(this.mockPublishSpan, times(1)).end();
+    if (isAck) {
+      pubsubMessageWrapper.startSubscribeAckSpan(mockTracer);
+      pubsubMessageWrapper.endSubscribeAckSpan();
+    } else {
+      // Nack
+      pubsubMessageWrapper.startSubscribeNackSpan(mockTracer);
+      pubsubMessageWrapper.endSubscribeNackSpan();
     }
 
-    @Test
-    public void testPublishSpansOutOfOrder() {
+    pubsubMessageWrapper.endSubscribeModAckSpan();
+    pubsubMessageWrapper.endSubscribeProcessSpan();
+    //    pubsubMessageWrapper.endSubscribeSchedulerSpan();
+    //    pubsubMessageWrapper.endSubscribeFlowControlSpan();
+    pubsubMessageWrapper.endSubscribeReceiveSpan();
 
-    }
+    verify(mockReceiveSpan, times(1)).end();
+    verify(mockProcessSpan, times(1)).end();
+    verify(mockModackSpan, times(1)).end();
+    verify(mockAckNackSpan, times(1)).end();
+  }
 
-    @Test
-    public void testPublishOptionalSpans() {}
-
-    private PubsubMessage getPubsubMessage() {
-        return PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8("sample-data")).build();
-    }
+  private PubsubMessage getPubsubMessage() {
+    return PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8("sample-data")).build();
+  }
 }

--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PubsubMessageWrapperTest.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PubsubMessageWrapperTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsub.v1;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class PubsubMessageWrapperTest {
+    @Rule public TestName testName = new TestName();
+
+    private static final String PUBLISH_SPAN_NAME = "projects/my-project/topics/my-topic send";
+    private static final String FLOW_CONTROL_SPAN_NAME = "publisher flow control";
+    private static final String PUBLISH_RPC_SPAN_NAME = "send Publish";
+
+    private Tracer mockTracer;
+    private Span mockPublishSpan;
+    private Span mockPublishRpcSpan;
+
+    @Before
+    public void setUp() {
+        // Setting up our mocks for consistency
+        this.mockTracer = mock(Tracer.class, RETURNS_DEEP_STUBS);
+        this.mockPublishSpan = mock(Span.class);
+        this.mockPublishRpcSpan = mock(Span.class);
+    }
+
+    @Test
+    public void testRequiredSpans() {
+        PubsubMessageWrapper pubsubMessageWrapper = new PubsubMessageWrapper(getPubsubMessage());
+
+        when(this.mockTracer.spanBuilder(PUBLISH_SPAN_NAME).startSpan()).thenReturn(this.mockPublishSpan);
+        when(this.mockTracer.spanBuilder(PUBLISH_RPC_SPAN_NAME).startSpan()).thenReturn(this.mockPublishSpan);
+
+        pubsubMessageWrapper.startPublishSpan(this.mockTracer);
+        pubsubMessageWrapper.startPublishRpcSpan(this.mockTracer);
+        pubsubMessageWrapper.endPublishRpcSpan();
+        pubsubMessageWrapper.endPublishSpan();
+
+        verify(this.mockPublishSpan, times(1)).end();
+    }
+
+    @Test
+    public void testPublishSpansOutOfOrder() {
+
+    }
+
+    @Test
+    public void testPublishOptionalSpans() {}
+
+    private PubsubMessage getPubsubMessage() {
+        return PubsubMessage.newBuilder().setData(ByteString.copyFromUtf8("sample-data")).build();
+    }
+}


### PR DESCRIPTION
Adding `PubsubMessageWrapper` to tie `PubsubMessage` and Open Telemetry spans together.

Also added framework for parameterized unit tests: https://github.com/google/TestParameterInjector