### PR TITLE
feat: setup 1.123.x lts branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -30,3 +30,7 @@ branches:
     handleGHRelease: true
     releaseType: java-backport
     branch: 1.121.x
+  - bumpMinorPreMajor: true
+    handleGHRelease: true
+    releaseType: java-backport
+    branch: 1.123.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -135,6 +135,23 @@ branchProtectionRules:
       - OwlBot Post Processor
       - 'Kokoro - Test: Java GraalVM Native Image'
       - 'Kokoro - Test: Java 17 GraalVM Native Image'
+  - pattern: 1.123.x
+    isAdminEnforced: true
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: false
+    requiredStatusCheckContexts:
+      - dependencies (17)
+      - lint
+      - clirr
+      - units (8)
+      - units (11)
+      - 'Kokoro - Test: Integration'
+      - Kokoro - Against Pub/Sub Lite samples
+      - cla/google
+      - OwlBot Post Processor
+      - 'Kokoro - Test: Java GraalVM Native Image'
+      - 'Kokoro - Test: Java 17 GraalVM Native Image'
 permissionRules:
   - team: yoshi-admins
     permission: admin


### PR DESCRIPTION
enable releases

```
release-brancher create-pull-request \
  --branch-name="1.123.x" \
  --target-tag="v1.123.18" \
  --repo="googleapis/java-pubsub" \
  --pull-request-title="feat: setup 1.123.x lts branch" \
  --release-type=java-backport
```

* This branch has been created based on 1.123.18, not 1.123.20 due to incompatible dependencies in 19+
* 'feat' commit ensures next release is 1.124.0