### PR TITLE
Update Publisher.java

### DIFF
--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
@@ -686,7 +686,7 @@ public class Publisher implements PublisherInterface {
     private static final Duration DEFAULT_TOTAL_TIMEOUT = Duration.ofSeconds(600);
     private static final Duration DEFAULT_INITIAL_RETRY_DELAY = Duration.ofMillis(100);
     private static final Duration DEFAULT_MAX_RETRY_DELAY = Duration.ofSeconds(60);
-    private static final double DEFAULT_MULTIPLIER = 1.3;
+    private static final double DEFAULT_MULTIPLIER = 4;
     static final BatchingSettings DEFAULT_BATCHING_SETTINGS =
         BatchingSettings.newBuilder()
             .setDelayThreshold(DEFAULT_DELAY_THRESHOLD)


### PR DESCRIPTION
Change default RetrySettings to use a multiplier of 4 instead of 1.3, to address aggressive retry on RESOURCE_EXHAUSTED errors. (Unfortunately, we can't set different retrySettings per error code.)

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/java-pubsub/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1685 ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
