### PR TITLE
build: do not declare javadoc plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.0</version>
         <reportSets>
           <reportSet>
             <id>html</id>


### PR DESCRIPTION
The maven-javadoc-plugin version is defined in the shared config pom.xml.
https://github.com/googleapis/java-shared-config/blob/778a547a09de71dbf9e5a42b155f12d15c319864/pom.xml#L472

The removal of the 4 lines corresponds to the lines touched by the recent RenovateBot:
https://github.com/googleapis/java-pubsub/pull/1733

Parent issue: https://github.com/googleapis/java-shared-config/issues/673