### PR TITLE
ci: setting up samples_build.yaml (2)

### DIFF
--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -26,5 +26,6 @@ steps:
   args: [
     'Samp[le job succeeded',
   ]
-
 timeout: 3600s
+options:
+  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -13,5 +13,10 @@ steps:
   ]
   env:
   - 'JOB_TYPE=samples'
+- name: gcr.io/cloud-devrel-kokoro-resources/java8
+  entrypoint: echo
+  args: [
+    'Samp[le job succeeded',
+  ]
 
 timeout: 300m

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -24,7 +24,7 @@ steps:
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: echo
   args: [
-    'Samp[le job succeeded',
+    'Sample job succeeded',
   ]
 timeout: 3600s
 options:

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -27,4 +27,4 @@ steps:
     'Samp[le job succeeded',
   ]
 
-timeout: 300m
+timeout: 3600s

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -1,19 +1,26 @@
 steps:
-- name: gcr.io/cloud-devrel-kokoro-resources/java8
+- name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: ls
   args: [
     '-alt',
   ]
-- name: gcr.io/cloud-devrel-kokoro-resources/java8
+- name: gcr.io/cloud-devrel-public-resources/java8
+  entrypoint: curl
+  args: [
+    '--header',
+    'Metadata-Flavor: Google',
+    'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email'
+  ]
+- name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: pwd
-- name: gcr.io/cloud-devrel-kokoro-resources/java8
+- name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: bash
   args: [
     './kokoro/build.sh'
   ]
   env:
   - 'JOB_TYPE=samples'
-- name: gcr.io/cloud-devrel-kokoro-resources/java8
+- name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: echo
   args: [
     'Samp[le job succeeded',

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -16,7 +16,7 @@ steps:
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: bash
   args: [
-    './kokoro/build.sh'
+    '.kokoro/build.sh'
   ]
   env:
   - 'JOB_TYPE=samples'

--- a/.cloudbuild/samples_build.yaml
+++ b/.cloudbuild/samples_build.yaml
@@ -20,6 +20,7 @@ steps:
   ]
   env:
   - 'JOB_TYPE=samples'
+  - 'GOOGLE_CLOUD_PROJECT=cloud-java-ci-sample'
 - name: gcr.io/cloud-devrel-public-resources/java8
   entrypoint: echo
   args: [

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you are using Maven without the BOM, add this to your dependencies:
 If you are using Gradle 5.x or later, add this to your dependencies:
 
 ```Groovy
-implementation platform('com.google.cloud:libraries-bom:26.32.0')
+implementation platform('com.google.cloud:libraries-bom:26.33.0')
 
 implementation 'com.google.cloud:google-cloud-pubsub'
 ```


### PR DESCRIPTION
Enhancing the sample_build.yaml gradually. Current status:

- AdminIT failed
- DeadLetterQueueIT succeeded
- PublisherIT succeeded
- SchemaIT succeeded
- SubscriberIT succeeded

Merging this for now as this has good progress itself. We'll address AdminIT in a subsequent pull request.

