### PR TITLE
chore: include recommended_package in repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -14,5 +14,6 @@
   "codeowner_team": "@googleapis/api-pubsub",
   "api_id": "pubsub.googleapis.com",
   "library_type": "GAPIC_COMBO",
-  "requires_billing": true
+  "requires_billing": true,
+  "recommended_package": "com.google.cloud.pubsub.v1"
 }


### PR DESCRIPTION
Adds a field for recommended_package as part of the revamped Library Overviews.
See go/cloud-rad-overviews-handwritten-repos for more details