### PR TITLE
chore: use sdk-platform-java-config instead of java-shared-config

### DIFF
--- a/google-cloud-pubsub-bom/pom.xml
+++ b/google-cloud-pubsub-bom/pom.xml
@@ -7,8 +7,8 @@
   <packaging>pom</packaging>
   <parent>
     <groupId>com.google.cloud</groupId>
-    <artifactId>google-cloud-shared-config</artifactId>
-    <version>1.9.1</version>
+    <artifactId>sdk-platform-java-config</artifactId>
+    <version>3.34.0</version>
   </parent>
 
   <name>Google Cloud pubsub BOM</name>


### PR DESCRIPTION
Missed updating this POM in https://github.com/googleapis/java-pubsub/pull/1895

Closes https://github.com/googleapis/java-pubsub/pull/2138