### PR TITLE
test: Fix flaky tests

### DIFF
--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
@@ -1342,6 +1342,7 @@ public class PublisherImplTest {
     fakeExecutor.advanceTime(Duration.ofSeconds(5));
     assertEquals("1", publishFuture.get());
     fakeExecutor.advanceTime(Duration.ofSeconds(5));
+    shutdownTestPublisher(publisher);
 
     List<SpanData> allSpans = openTelemetryTesting.getSpans();
     assertEquals(4, allSpans.size());

--- a/samples/snippets/src/test/java/pubsub/AdminIT.java
+++ b/samples/snippets/src/test/java/pubsub/AdminIT.java
@@ -81,8 +81,8 @@ public class AdminIT {
   private static final String cloudStorageInputFormat = "text";
   private static final String cloudStorageTextDelimiter = ",";
   private static final String cloudStorageMatchGlob = "**.txt";
-  private static final String cloudStorageMinimumObjectCreateTime = "1970-01-01T00:00:00Z";
-  private static final String cloudStorageMinimumObjectCreateTimeSeconds = "0";
+  private static final String cloudStorageMinimumObjectCreateTime = "1970-01-01T00:00:01Z";
+  private static final String cloudStorageMinimumObjectCreateTimeSeconds = "seconds: 1";
 
   private static final TopicName topicName = TopicName.of(projectId, topicId);
   private static final TopicName kinesisIngestionTopicName =

--- a/samples/snippets/src/test/java/pubsub/SubscriberIT.java
+++ b/samples/snippets/src/test/java/pubsub/SubscriberIT.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;

--- a/samples/snippets/src/test/java/pubsub/SubscriberIT.java
+++ b/samples/snippets/src/test/java/pubsub/SubscriberIT.java
@@ -47,8 +47,8 @@ import org.junit.Test;
 import org.junit.rules.Timeout;
 
 public class SubscriberIT {
-  private ByteArrayOutputStream bout;
-  private PrintStream out;
+  private static ByteArrayOutputStream bout;
+  private static PrintStream out;
 
   private static final String projectId = System.getenv("GOOGLE_CLOUD_PROJECT");
   private static final String _suffix = UUID.randomUUID().toString();
@@ -131,7 +131,7 @@ public class SubscriberIT {
   }
 
   @BeforeClass
-  public void setUp() throws Exception {
+  public static void setUp() throws Exception {
     bout = new ByteArrayOutputStream();
     out = new PrintStream(bout);
     System.setOut(out);
@@ -164,7 +164,7 @@ public class SubscriberIT {
   }
 
   @AfterClass
-  public void tearDown() throws Exception {
+  public static void tearDown() throws Exception {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       subscriptionAdminClient.deleteSubscription(subscriptionName.toString());
       subscriptionAdminClient.deleteSubscription(subscriptionEodName.toString());

--- a/samples/snippets/src/test/java/pubsub/SubscriberIT.java
+++ b/samples/snippets/src/test/java/pubsub/SubscriberIT.java
@@ -160,7 +160,7 @@ public class SubscriberIT {
               .build();
       Subscription createdSubscriptionEod =
           subscriptionAdminClient.createSubscription(subscriptionEod);
-      System.out.println("Created subscription: " + createdSubscriptionEod.getName());
+      System.err.println("Created subscription: " + createdSubscriptionEod.getName());
     }
   }
 

--- a/samples/snippets/src/test/java/pubsub/SubscriberIT.java
+++ b/samples/snippets/src/test/java/pubsub/SubscriberIT.java
@@ -129,7 +129,7 @@ public class SubscriberIT {
     requireEnvVar("GOOGLE_CLOUD_PROJECT");
   }
 
-  @Before
+  @BeforeClass
   public void setUp() throws Exception {
     bout = new ByteArrayOutputStream();
     out = new PrintStream(bout);
@@ -164,7 +164,7 @@ public class SubscriberIT {
     }
   }
 
-  @After
+  @AfterClass
   public void tearDown() throws Exception {
     try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create()) {
       subscriptionAdminClient.deleteSubscription(subscriptionName.toString());

--- a/samples/snippets/src/test/java/pubsub/SubscriberIT.java
+++ b/samples/snippets/src/test/java/pubsub/SubscriberIT.java
@@ -158,9 +158,7 @@ public class SubscriberIT {
               // Enable exactly once delivery in the subscription.
               .setEnableExactlyOnceDelivery(true)
               .build();
-      Subscription createdSubscriptionEod =
-          subscriptionAdminClient.createSubscription(subscriptionEod);
-      System.err.println("Created subscription: " + createdSubscriptionEod.getName());
+      subscriptionAdminClient.createSubscription(subscriptionEod);
     }
   }
 

--- a/samples/snippets/src/test/java/pubsub/SubscriberIT.java
+++ b/samples/snippets/src/test/java/pubsub/SubscriberIT.java
@@ -158,7 +158,9 @@ public class SubscriberIT {
               // Enable exactly once delivery in the subscription.
               .setEnableExactlyOnceDelivery(true)
               .build();
-      subscriptionAdminClient.createSubscription(subscriptionEod);
+      Subscription createdSubscriptionEod =
+          subscriptionAdminClient.createSubscription(subscriptionEod);
+      System.out.println("Created subscription: " + createdSubscriptionEod.getName());
     }
   }
 


### PR DESCRIPTION
Fixes a flaky test for the EOD subscription sample. Currently, the test creates and deletes subscriptions before and after every test, but I believe this is causing flaky results. This only runs setUp and tearDown before and after the whole test suite.

This also fixes the GCS ingestion topic, by ensuring the minimum object create time is properly found in the topic definition.

Lastly, this fixes a flaky OpenTelemetry test by ensuring that the publisher is shutdown and all spans are ended.