### PR TITLE
feat: introduce `java.time` variables and methods

### DIFF
--- a/google-cloud-pubsub/clirr-ignored-differences.xml
+++ b/google-cloud-pubsub/clirr-ignored-differences.xml
@@ -1,4 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
 <differences>
+    <difference>
+        <differenceType>7005</differenceType>
+        <!--Ignore changes in this class because it's package private-->
+        <className>com/google/cloud/pubsub/v1/MessageDispatcher$Builder</className>
+        <method>*(org.threeten.bp.Duration)</method>
+        <to>*(java.time.Duration)</to>
+    </difference>
+    <difference>
+        <differenceType>7005</differenceType>
+        <!--Ignore changes in this class because it's package private-->
+        <className>com/google/cloud/pubsub/v1/StreamingSubscriberConnection$Builder</className>
+        <method>*(org.threeten.bp.Duration)</method>
+        <to>*(java.time.Duration)</to>
+    </difference>
 </differences>

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/MessageDispatcher.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/MessageDispatcher.java
@@ -28,6 +28,9 @@ import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.ReceivedMessage;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -48,9 +51,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.threeten.bp.Duration;
-import org.threeten.bp.Instant;
-import org.threeten.bp.temporal.ChronoUnit;
 
 /**
  * Dispatches messages to a message receiver while handling the messages acking and lease

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
@@ -57,6 +57,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -73,7 +74,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.threeten.bp.Duration;
 
 /**
  * A Cloud Pub/Sub <a href="https://cloud.google.com/pubsub/docs/publisher">publisher</a>, that is
@@ -198,7 +198,7 @@ public class Publisher implements PublisherInterface {
       // key?
       retrySettingsBuilder
           .setMaxAttempts(Integer.MAX_VALUE)
-          .setTotalTimeout(Duration.ofNanos(Long.MAX_VALUE));
+          .setTotalTimeoutDuration(Duration.ofNanos(Long.MAX_VALUE));
     }
 
     PublisherStubSettings.Builder stubSettings =
@@ -740,7 +740,7 @@ public class Publisher implements PublisherInterface {
     private static final double DEFAULT_MULTIPLIER = 4;
     static final BatchingSettings DEFAULT_BATCHING_SETTINGS =
         BatchingSettings.newBuilder()
-            .setDelayThreshold(DEFAULT_DELAY_THRESHOLD)
+            .setDelayThresholdDuration(DEFAULT_DELAY_THRESHOLD)
             .setRequestByteThreshold(DEFAULT_REQUEST_BYTES_THRESHOLD)
             .setElementCountThreshold(DEFAULT_ELEMENT_COUNT_THRESHOLD)
             .setFlowControlSettings(
@@ -750,13 +750,13 @@ public class Publisher implements PublisherInterface {
             .build();
     static final RetrySettings DEFAULT_RETRY_SETTINGS =
         RetrySettings.newBuilder()
-            .setTotalTimeout(DEFAULT_TOTAL_TIMEOUT)
-            .setInitialRetryDelay(DEFAULT_INITIAL_RETRY_DELAY)
+            .setTotalTimeoutDuration(DEFAULT_TOTAL_TIMEOUT)
+            .setInitialRetryDelayDuration(DEFAULT_INITIAL_RETRY_DELAY)
             .setRetryDelayMultiplier(DEFAULT_MULTIPLIER)
-            .setMaxRetryDelay(DEFAULT_MAX_RETRY_DELAY)
-            .setInitialRpcTimeout(DEFAULT_INITIAL_RPC_TIMEOUT)
+            .setMaxRetryDelayDuration(DEFAULT_MAX_RETRY_DELAY)
+            .setInitialRpcTimeoutDuration(DEFAULT_INITIAL_RPC_TIMEOUT)
             .setRpcTimeoutMultiplier(DEFAULT_MULTIPLIER)
-            .setMaxRpcTimeout(DEFAULT_MAX_RPC_TIMEOUT)
+            .setMaxRpcTimeoutDuration(DEFAULT_MAX_RPC_TIMEOUT)
             .build();
     static final boolean DEFAULT_ENABLE_MESSAGE_ORDERING = false;
     private static final int THREADS_PER_CPU = 5;
@@ -876,9 +876,9 @@ public class Publisher implements PublisherInterface {
     /** Configures the Publisher's retry parameters. */
     public Builder setRetrySettings(RetrySettings retrySettings) {
       Preconditions.checkArgument(
-          retrySettings.getTotalTimeout().compareTo(MIN_TOTAL_TIMEOUT) >= 0);
+          retrySettings.getTotalTimeoutDuration().compareTo(MIN_TOTAL_TIMEOUT) >= 0);
       Preconditions.checkArgument(
-          retrySettings.getInitialRpcTimeout().compareTo(MIN_RPC_TIMEOUT) >= 0);
+          retrySettings.getInitialRpcTimeoutDuration().compareTo(MIN_RPC_TIMEOUT) >= 0);
       this.retrySettings = retrySettings;
       return this;
     }

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/StreamingSubscriberConnection.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/StreamingSubscriberConnection.java
@@ -51,6 +51,7 @@ import com.google.rpc.ErrorInfo;
 import io.grpc.Status;
 import io.grpc.protobuf.StatusProto;
 import io.opentelemetry.api.trace.Span;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -68,7 +69,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
-import org.threeten.bp.Duration;
 
 /** Implementation of {@link AckProcessor} based on Cloud Pub/Sub streaming pull. */
 final class StreamingSubscriberConnection extends AbstractApiService implements AckProcessor {

--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/FakePublisherServiceImpl.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/FakePublisherServiceImpl.java
@@ -21,13 +21,13 @@ import com.google.pubsub.v1.PublishRequest;
 import com.google.pubsub.v1.PublishResponse;
 import com.google.pubsub.v1.PublisherGrpc.PublisherImplBase;
 import io.grpc.stub.StreamObserver;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.threeten.bp.Duration;
 
 /**
  * A fake implementation of {@link PublisherImplBase}, that can be used to test clients of a Cloud

--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/FakeScheduledExecutorService.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/FakeScheduledExecutorService.java
@@ -18,6 +18,8 @@ package com.google.cloud.pubsub.v1;
 
 import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.SettableFuture;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedList;
@@ -32,8 +34,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.threeten.bp.Duration;
-import org.threeten.bp.Instant;
 
 /**
  * Fake implementation of {@link ScheduledExecutorService} that allows tests control the reference

--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/MessageDispatcherTest.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/MessageDispatcherTest.java
@@ -26,13 +26,13 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.ReceivedMessage;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.threeten.bp.Duration;
 
 public class MessageDispatcherTest {
   private static final ByteString MESSAGE_DATA = ByteString.copyFromUtf8("message-data");

--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
@@ -54,6 +54,7 @@ import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
 import io.opentelemetry.sdk.testing.assertj.SpanDataAssert;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -66,7 +67,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.threeten.bp.Duration;
 
 @RunWith(JUnit4.class)
 public class PublisherImplTest {
@@ -120,7 +120,7 @@ public class PublisherImplTest {
             .setBatchingSettings(
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
-                    .setDelayThreshold(Duration.ofSeconds(5))
+                    .setDelayThresholdDuration(Duration.ofSeconds(5))
                     .setElementCountThreshold(10L)
                     .build())
             .build();
@@ -151,7 +151,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(2L)
-                    .setDelayThreshold(Duration.ofSeconds(100))
+                    .setDelayThresholdDuration(Duration.ofSeconds(100))
                     .build())
             .build();
 
@@ -190,7 +190,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(2L)
-                    .setDelayThreshold(Duration.ofSeconds(100))
+                    .setDelayThresholdDuration(Duration.ofSeconds(100))
                     .build())
             .build();
 
@@ -225,7 +225,7 @@ public class PublisherImplTest {
             .setBatchingSettings(
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
-                    .setDelayThreshold(Duration.ofSeconds(100))
+                    .setDelayThresholdDuration(Duration.ofSeconds(100))
                     .setElementCountThreshold(10L)
                     .build())
             .build();
@@ -259,7 +259,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(2L)
-                    .setDelayThreshold(Duration.ofSeconds(5))
+                    .setDelayThresholdDuration(Duration.ofSeconds(5))
                     .build())
             .build();
 
@@ -300,7 +300,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(2L)
-                    .setDelayThreshold(Duration.ofSeconds(100))
+                    .setDelayThresholdDuration(Duration.ofSeconds(100))
                     .build())
             .setEnableCompression(true)
             .setCompressionBytesThreshold(100)
@@ -331,7 +331,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(3L)
-                    .setDelayThreshold(Duration.ofSeconds(100))
+                    .setDelayThresholdDuration(Duration.ofSeconds(100))
                     .build())
             .setEnableMessageOrdering(true)
             .build();
@@ -384,7 +384,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(10L)
-                    .setDelayThreshold(Duration.ofSeconds(100))
+                    .setDelayThresholdDuration(Duration.ofSeconds(100))
                     .build())
             .setEnableMessageOrdering(true)
             .build();
@@ -448,7 +448,7 @@ public class PublisherImplTest {
                     .toBuilder()
                     .setElementCountThreshold(10L)
                     .setRequestByteThreshold(64L)
-                    .setDelayThreshold(Duration.ofSeconds(100))
+                    .setDelayThresholdDuration(Duration.ofSeconds(100))
                     .build())
             .setEnableMessageOrdering(true)
             .build();
@@ -490,7 +490,7 @@ public class PublisherImplTest {
             .setRetrySettings(
                 Publisher.Builder.DEFAULT_RETRY_SETTINGS
                     .toBuilder()
-                    .setTotalTimeout(Duration.ofSeconds(10))
+                    .setTotalTimeoutDuration(Duration.ofSeconds(10))
                     .setMaxAttempts(1)
                     .build())
             .setEnableMessageOrdering(true)
@@ -613,7 +613,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(2L)
-                    .setDelayThreshold(Duration.ofSeconds(500))
+                    .setDelayThresholdDuration(Duration.ofSeconds(500))
                     .build())
             .setEnableMessageOrdering(true)
             .build();
@@ -674,7 +674,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(1L)
-                    .setDelayThreshold(Duration.ofSeconds(5))
+                    .setDelayThresholdDuration(Duration.ofSeconds(5))
                     .build())
             .build();
     testPublisherServiceImpl.addPublishError(Status.DATA_LOSS.asException());
@@ -695,7 +695,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(1L)
-                    .setDelayThreshold(Duration.ofSeconds(5))
+                    .setDelayThresholdDuration(Duration.ofSeconds(5))
                     .build())
             .build(); // To demonstrate that reaching duration will trigger publish
 
@@ -718,7 +718,7 @@ public class PublisherImplTest {
             .setRetrySettings(
                 Publisher.Builder.DEFAULT_RETRY_SETTINGS
                     .toBuilder()
-                    .setTotalTimeout(Duration.ofSeconds(10))
+                    .setTotalTimeoutDuration(Duration.ofSeconds(10))
                     .setMaxAttempts(1)
                     .build())
             .build();
@@ -743,7 +743,7 @@ public class PublisherImplTest {
             .setRetrySettings(
                 Publisher.Builder.DEFAULT_RETRY_SETTINGS
                     .toBuilder()
-                    .setTotalTimeout(Duration.ofSeconds(10))
+                    .setTotalTimeoutDuration(Duration.ofSeconds(10))
                     .setMaxAttempts(3)
                     .build())
             .build();
@@ -768,7 +768,7 @@ public class PublisherImplTest {
             .setRetrySettings(
                 Publisher.Builder.DEFAULT_RETRY_SETTINGS
                     .toBuilder()
-                    .setTotalTimeout(Duration.ofSeconds(10))
+                    .setTotalTimeoutDuration(Duration.ofSeconds(10))
                     .setMaxAttempts(0)
                     .build())
             .build();
@@ -794,13 +794,13 @@ public class PublisherImplTest {
             .setRetrySettings(
                 Publisher.Builder.DEFAULT_RETRY_SETTINGS
                     .toBuilder()
-                    .setTotalTimeout(Duration.ofSeconds(10))
+                    .setTotalTimeoutDuration(Duration.ofSeconds(10))
                     .build())
             .setBatchingSettings(
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(1L)
-                    .setDelayThreshold(Duration.ofSeconds(5))
+                    .setDelayThresholdDuration(Duration.ofSeconds(5))
                     .build())
             .build(); // To demonstrate that reaching duration will trigger publish
 
@@ -825,7 +825,7 @@ public class PublisherImplTest {
     builder.setBatchingSettings(
         BatchingSettings.newBuilder()
             .setRequestByteThreshold(10L)
-            .setDelayThreshold(Duration.ofMillis(11))
+            .setDelayThresholdDuration(Duration.ofMillis(11))
             .setElementCountThreshold(12L)
             .build());
     builder.setCredentialsProvider(NoCredentialsProvider.create());
@@ -833,7 +833,8 @@ public class PublisherImplTest {
 
     assertEquals(TEST_TOPIC, publisher.getTopicName());
     assertEquals(10, (long) publisher.getBatchingSettings().getRequestByteThreshold());
-    assertEquals(Duration.ofMillis(11), publisher.getBatchingSettings().getDelayThreshold());
+    assertEquals(
+        Duration.ofMillis(11), publisher.getBatchingSettings().getDelayThresholdDuration());
     assertEquals(12, (long) publisher.getBatchingSettings().getElementCountThreshold());
     publisher.shutdown();
     assertTrue(publisher.awaitTermination(1, TimeUnit.MINUTES));
@@ -848,7 +849,8 @@ public class PublisherImplTest {
         Publisher.Builder.DEFAULT_REQUEST_BYTES_THRESHOLD,
         builder.batchingSettings.getRequestByteThreshold().longValue());
     assertEquals(
-        Publisher.Builder.DEFAULT_DELAY_THRESHOLD, builder.batchingSettings.getDelayThreshold());
+        Publisher.Builder.DEFAULT_DELAY_THRESHOLD,
+        builder.batchingSettings.getDelayThresholdDuration());
     assertEquals(
         Publisher.Builder.DEFAULT_ELEMENT_COUNT_THRESHOLD,
         builder.batchingSettings.getElementCountThreshold().longValue());
@@ -906,7 +908,7 @@ public class PublisherImplTest {
     builder.setBatchingSettings(
         Publisher.Builder.DEFAULT_BATCHING_SETTINGS
             .toBuilder()
-            .setDelayThreshold(Duration.ofMillis(1))
+            .setDelayThresholdDuration(Duration.ofMillis(1))
             .build());
     try {
       builder.setBatchingSettings(
@@ -919,7 +921,7 @@ public class PublisherImplTest {
       builder.setBatchingSettings(
           Publisher.Builder.DEFAULT_BATCHING_SETTINGS
               .toBuilder()
-              .setDelayThreshold(Duration.ofMillis(-1))
+              .setDelayThresholdDuration(Duration.ofMillis(-1))
               .build());
       fail("Should have thrown an IllegalArgumentException");
     } catch (IllegalArgumentException expected) {
@@ -965,13 +967,13 @@ public class PublisherImplTest {
     builder.setRetrySettings(
         Publisher.Builder.DEFAULT_RETRY_SETTINGS
             .toBuilder()
-            .setInitialRpcTimeout(Publisher.Builder.MIN_RPC_TIMEOUT)
+            .setInitialRpcTimeoutDuration(Publisher.Builder.MIN_RPC_TIMEOUT)
             .build());
     try {
       builder.setRetrySettings(
           Publisher.Builder.DEFAULT_RETRY_SETTINGS
               .toBuilder()
-              .setInitialRpcTimeout(Publisher.Builder.MIN_RPC_TIMEOUT.minusMillis(1))
+              .setInitialRpcTimeoutDuration(Publisher.Builder.MIN_RPC_TIMEOUT.minusMillis(1))
               .build());
       fail("Should have thrown an IllegalArgumentException");
     } catch (IllegalArgumentException expected) {
@@ -980,13 +982,13 @@ public class PublisherImplTest {
     builder.setRetrySettings(
         Publisher.Builder.DEFAULT_RETRY_SETTINGS
             .toBuilder()
-            .setTotalTimeout(Publisher.Builder.MIN_TOTAL_TIMEOUT)
+            .setTotalTimeoutDuration(Publisher.Builder.MIN_TOTAL_TIMEOUT)
             .build());
     try {
       builder.setRetrySettings(
           Publisher.Builder.DEFAULT_RETRY_SETTINGS
               .toBuilder()
-              .setTotalTimeout(Publisher.Builder.MIN_TOTAL_TIMEOUT.minusMillis(1))
+              .setTotalTimeoutDuration(Publisher.Builder.MIN_TOTAL_TIMEOUT.minusMillis(1))
               .build());
       fail("Should have thrown an IllegalArgumentException");
     } catch (IllegalArgumentException expected) {
@@ -1031,7 +1033,7 @@ public class PublisherImplTest {
             .setRetrySettings(
                 Publisher.Builder.DEFAULT_RETRY_SETTINGS
                     .toBuilder()
-                    .setTotalTimeout(Duration.ofSeconds(10))
+                    .setTotalTimeoutDuration(Duration.ofSeconds(10))
                     .setMaxAttempts(0)
                     .build())
             .build();
@@ -1066,7 +1068,7 @@ public class PublisherImplTest {
                   Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                       .toBuilder()
                       .setElementCountThreshold(1L)
-                      .setDelayThreshold(Duration.ofSeconds(5))
+                      .setDelayThresholdDuration(Duration.ofSeconds(5))
                       .setFlowControlSettings(
                           FlowControlSettings.newBuilder()
                               .setLimitExceededBehavior(
@@ -1091,7 +1093,7 @@ public class PublisherImplTest {
                   Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                       .toBuilder()
                       .setElementCountThreshold(1L)
-                      .setDelayThreshold(Duration.ofSeconds(5))
+                      .setDelayThresholdDuration(Duration.ofSeconds(5))
                       .setFlowControlSettings(
                           FlowControlSettings.newBuilder()
                               .setLimitExceededBehavior(
@@ -1116,7 +1118,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(1L)
-                    .setDelayThreshold(Duration.ofSeconds(5))
+                    .setDelayThresholdDuration(Duration.ofSeconds(5))
                     .setFlowControlSettings(
                         FlowControlSettings.newBuilder()
                             .setLimitExceededBehavior(FlowController.LimitExceededBehavior.Block)
@@ -1144,7 +1146,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(1L)
-                    .setDelayThreshold(Duration.ofSeconds(5))
+                    .setDelayThresholdDuration(Duration.ofSeconds(5))
                     .setFlowControlSettings(
                         FlowControlSettings.newBuilder()
                             .setLimitExceededBehavior(
@@ -1186,7 +1188,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(1L)
-                    .setDelayThreshold(Duration.ofSeconds(5))
+                    .setDelayThresholdDuration(Duration.ofSeconds(5))
                     .setFlowControlSettings(
                         FlowControlSettings.newBuilder()
                             .setLimitExceededBehavior(
@@ -1233,7 +1235,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(1L)
-                    .setDelayThreshold(Duration.ofSeconds(5))
+                    .setDelayThresholdDuration(Duration.ofSeconds(5))
                     .setFlowControlSettings(
                         FlowControlSettings.newBuilder()
                             .setLimitExceededBehavior(FlowController.LimitExceededBehavior.Block)
@@ -1325,7 +1327,7 @@ public class PublisherImplTest {
                 Publisher.Builder.DEFAULT_BATCHING_SETTINGS
                     .toBuilder()
                     .setElementCountThreshold(1L)
-                    .setDelayThreshold(Duration.ofSeconds(5))
+                    .setDelayThresholdDuration(Duration.ofSeconds(5))
                     .setFlowControlSettings(
                         FlowControlSettings.newBuilder()
                             .setLimitExceededBehavior(FlowController.LimitExceededBehavior.Block)

--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/StreamingSubscriberConnectionTest.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/StreamingSubscriberConnectionTest.java
@@ -34,6 +34,7 @@ import com.google.rpc.ErrorInfo;
 import com.google.rpc.Status;
 import io.grpc.StatusException;
 import io.grpc.protobuf.StatusProto;
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
@@ -41,7 +42,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-import org.threeten.bp.Duration;
 
 /** Tests for {@link StreamingSubscriberConnection}. */
 public class StreamingSubscriberConnectionTest {

--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/SubscriberTest.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/SubscriberTest.java
@@ -35,13 +35,13 @@ import io.grpc.Status;
 import io.grpc.StatusException;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
+import java.time.Duration;
 import java.util.concurrent.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-import org.threeten.bp.Duration;
 
 /** Tests for {@link Subscriber}. */
 public class SubscriberTest {
@@ -241,7 +241,8 @@ public class SubscriberTest {
     Subscriber subscriber =
         startSubscriber(
             getTestSubscriberBuilder(testReceiver)
-                .setMaxDurationPerAckExtension(Duration.ofSeconds(maxDurationPerAckExtension)));
+                .setMaxDurationPerAckExtensionDuration(
+                    Duration.ofSeconds(maxDurationPerAckExtension)));
     assertEquals(
         expectedChannelCount, fakeSubscriberServiceImpl.waitForOpenedStreams(expectedChannelCount));
     assertEquals(
@@ -255,7 +256,8 @@ public class SubscriberTest {
     subscriber =
         startSubscriber(
             getTestSubscriberBuilder(testReceiver)
-                .setMaxDurationPerAckExtension(Duration.ofSeconds(maxDurationPerAckExtension)));
+                .setMaxDurationPerAckExtensionDuration(
+                    Duration.ofSeconds(maxDurationPerAckExtension)));
     assertEquals(
         expectedChannelCount, fakeSubscriberServiceImpl.waitForOpenedStreams(expectedChannelCount));
     assertEquals(
@@ -269,7 +271,8 @@ public class SubscriberTest {
     subscriber =
         startSubscriber(
             getTestSubscriberBuilder(testReceiver)
-                .setMaxDurationPerAckExtension(Duration.ofSeconds(maxDurationPerAckExtension)));
+                .setMaxDurationPerAckExtensionDuration(
+                    Duration.ofSeconds(maxDurationPerAckExtension)));
     assertEquals(
         expectedChannelCount, fakeSubscriberServiceImpl.waitForOpenedStreams(expectedChannelCount));
     assertEquals(


### PR DESCRIPTION
This PR introduces `java.time` alternatives to existing `org.threeten.bp.*` methods, as well as switching internal variables (if any) to `java.time`

The main constraint is to keep the changes backwards compatible, so for each existing threeten method "`method1(org.threeten.bp.Duration)`" we will add an alternative with a _Duration_ (or _Timestamp_ when applicable) suffix: "`method1Duration(java.time.Duration)`".

For most cases, the implementation will be held in the `java.time` method and the old threeten method will just delegate the call to it. However, for the case of abstract classes, the implementation will be kept in the threeten method to avoid breaking changes (i.e. users that already overloaded the method in their user code).