### PR TITLE
Use correct OpenTelemetry Semconv

### DIFF
--- a/google-cloud-pubsub/pom.xml
+++ b/google-cloud-pubsub/pom.xml
@@ -109,7 +109,7 @@
       <artifactId>opentelemetry-context</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.opentelemetry</groupId>
+      <groupId>io.opentelemetry.semconv</groupId>
       <artifactId>opentelemetry-semconv</artifactId>
     </dependency>
 


### PR DESCRIPTION
Very welcome to close this and do it yourself, but we hit a dependency issue recently that seems to be coming from here.

The Semantic Convention jar moved group. See https://github.com/open-telemetry/semantic-conventions-java and https://github.com/open-telemetry/opentelemetry-java/blob/7829f53c247b6741866ff71181bd39e28988a415/CHANGELOG.md?plain=1#L771

> * BREAKING: Stop publishing `io.opentelemetry:opentelemetry-semconv`. Please use
  `io.opentelemetry.semconv:opentelemetry-semconv:1.21.0-alpha` instead, which is published
  from [open-telemetry/semantic-conventions-java](https://github.com/open-telemetry/semantic-conventions-java).
  The new repository is published in lockstep
  with [open-telemetry/semantic-conventions](https://github.com/open-telemetry/semantic-conventions).
  ([#5807](https://github.com/open-telemetry/opentelemetry-java/pull/5807))