### PR TITLE
test: option to use snapshot repository in an artifact registry [not for review]

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,9 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <!-- Extension to allow us to use the "artifactregistry://" URL scheme -->
+    <extension>
+        <groupId>com.google.cloud.artifactregistry</groupId>
+        <artifactId>artifactregistry-maven-wagon</artifactId>
+        <version>2.2.5</version>
+    </extension>
+</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -214,4 +214,21 @@
       </plugin>
     </plugins>
   </reporting>
+  <profiles>
+    <profile>
+      <id>use-snapshot-repo</id>
+      <repositories>
+        <repository>
+          <id>artifact-registry</id>
+          <url>artifactregistry://us-maven.pkg.dev/suztomo-cloud-function-test/test-maven-repo-snapshot</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
I'm experimenting a way to run integration tests with the shared dependencies BOM that's uploaded to a repository in Google Artifact Registry.
