### PR TITLE
docs(sample): Update the subscribe with error listener and subscribe with exactly-once samples

### DIFF
--- a/samples/snippets/src/main/java/pubsub/SubscribeWithErrorListenerExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeWithErrorListenerExample.java
@@ -62,15 +62,11 @@ public class SubscribeWithErrorListenerExample {
               .setExecutorProvider(executorProvider)
               .build();
 
-      // Listen for unrecoverable failures. Rebuild a subscriber and restart subscribing
-      // when the current subscriber encounters permanent errors.
+      // Listen for unrecoverable failures.
       subscriber.addListener(
           new Subscriber.Listener() {
             public void failed(Subscriber.State from, Throwable failure) {
-              System.out.println(failure.getStackTrace());
-              if (!executorProvider.getExecutor().isShutdown()) {
-                subscribeWithErrorListenerExample(projectId, subscriptionId);
-              }
+              System.out.println("Unrecoverable subscriber failure:" + failure.getStackTrace());
             }
           },
           MoreExecutors.directExecutor());

--- a/samples/snippets/src/main/java/pubsub/SubscribeWithExactlyOnceConsumerWithResponseExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeWithExactlyOnceConsumerWithResponseExample.java
@@ -95,7 +95,10 @@ public class SubscribeWithExactlyOnceConsumerWithResponseExample {
 
     Subscriber subscriber = null;
     try {
-      subscriber = Subscriber.newBuilder(subscriptionName, receiverWithResponse).build();
+      subscriber =
+          Subscriber.newBuilder(subscriptionName, receiverWithResponse)
+              .setEndpoint("us-west1-pubsub.googleapis.com:443")
+              .build();
       // Start the subscriber.
       subscriber.startAsync().awaitRunning();
       System.out.printf("Listening for messages on %s:\n", subscriptionName.toString());

--- a/samples/snippets/src/main/java/pubsub/SubscribeWithExactlyOnceConsumerWithResponseExample.java
+++ b/samples/snippets/src/main/java/pubsub/SubscribeWithExactlyOnceConsumerWithResponseExample.java
@@ -95,6 +95,10 @@ public class SubscribeWithExactlyOnceConsumerWithResponseExample {
 
     Subscriber subscriber = null;
     try {
+      // Pub/Sub's exactly once delivery guarantee only applies when subscribers connect to the
+      // service in the same region.
+      // For list of locational endpoints for Pub/Sub, see
+      // https://cloud.google.com/pubsub/docs/reference/service_apis_overview#list_of_locational_endpoints
       subscriber =
           Subscriber.newBuilder(subscriptionName, receiverWithResponse)
               .setEndpoint("us-west1-pubsub.googleapis.com:443")


### PR DESCRIPTION
- Update the subscribe with error listener to not recreate the subscriber client on unrecoverable failures.
- Update the subscribe with exactly-once sample to use a locational endpoint