### PR TITLE
fix: Use the system executor instead of a separate thread pool for EOD ack/modack callbacks

### DIFF
--- a/google-cloud-pubsub/clirr-ignored-differences.xml
+++ b/google-cloud-pubsub/clirr-ignored-differences.xml
@@ -15,4 +15,10 @@
         <method>*(org.threeten.bp.Duration)</method>
         <to>*(java.time.Duration)</to>
     </difference>
+    <difference>
+        <differenceType>7002</differenceType>
+        <!--Ignore changes in this class because it's package private-->
+        <className>com/google/cloud/pubsub/v1/StreamingSubscriberConnection$Builder</className>
+        <method>setEodAckCallbackExecutor(java.util.concurrent.ExecutorService)</method>
+    </difference>
 </differences>

--- a/google-cloud-pubsub/clirr-ignored-differences.xml
+++ b/google-cloud-pubsub/clirr-ignored-differences.xml
@@ -19,6 +19,6 @@
         <differenceType>7002</differenceType>
         <!--Ignore changes in this class because it's package private-->
         <className>com/google/cloud/pubsub/v1/StreamingSubscriberConnection$Builder</className>
-        <method>setEodAckCallbackExecutor(java.util.concurrent.ExecutorService)</method>
+        <method>* setEodAckCallbackExecutor(*)</method>
     </difference>
 </differences>

--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Subscriber.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Subscriber.java
@@ -51,7 +51,6 @@ import io.opentelemetry.api.trace.Tracer;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -151,8 +150,6 @@ public class Subscriber extends AbstractApiService implements SubscriberInterfac
   // An instantiation of the SystemExecutorProvider used for processing acks
   // and other system actions.
   @Nullable private final ScheduledExecutorService alarmsExecutor;
-  // An executor used for handling ack and modack callbacks when exactly-once delivery is enabled.
-  private final ExecutorService eodAckCallbackExecutor;
 
   private final Distribution ackLatencyDistribution =
       new Distribution(Math.toIntExact(MAX_STREAM_ACK_DEADLINE.getSeconds()) + 1);
@@ -203,15 +200,6 @@ public class Subscriber extends AbstractApiService implements SubscriberInterfac
     if (systemExecutorProvider.shouldAutoClose()) {
       backgroundResources.add(new ExecutorAsBackgroundResource((alarmsExecutor)));
     }
-
-    // A cached thread pool will create new threads as needed but can reuse previously constructed
-    // threads when available, which helps to improve performance.
-    ThreadFactory eodAckCallbackThreadFactory =
-        new ThreadFactoryBuilder()
-            .setDaemon(true)
-            .setNameFormat("Subscriber-EOD-CallbackExecutor-%d")
-            .build();
-    eodAckCallbackExecutor = Executors.newCachedThreadPool(eodAckCallbackThreadFactory);
 
     TransportChannelProvider channelProvider = builder.channelProvider;
     if (channelProvider.acceptsPoolSize()) {
@@ -429,7 +417,6 @@ public class Subscriber extends AbstractApiService implements SubscriberInterfac
                 .setUseLegacyFlowControl(useLegacyFlowControl)
                 .setExecutor(executor)
                 .setSystemExecutor(alarmsExecutor)
-                .setEodAckCallbackExecutor(eodAckCallbackExecutor)
                 .setClock(clock)
                 .setEnableOpenTelemetryTracing(enableOpenTelemetryTracing)
                 .setTracer(tracer)

--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/StreamingSubscriberConnectionTest.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/StreamingSubscriberConnectionTest.java
@@ -587,7 +587,6 @@ public class StreamingSubscriberConnectionTest {
         .setFlowController(mock(FlowController.class))
         .setExecutor(executor)
         .setSystemExecutor(systemExecutor)
-        .setEodAckCallbackExecutor(systemExecutor)
         .setClock(clock)
         .setMinDurationPerAckExtension(Subscriber.DEFAULT_MIN_ACK_DEADLINE_EXTENSION)
         .setMinDurationPerAckExtensionDefaultUsed(true)


### PR DESCRIPTION
Avoids the use of an additional executor to give users more control over their executors and number of threads. This is an update to PR #2505.

Fixes #2480