### PR TITLE
feat: Enforcing max limits set by getApiMaxRequestElementCount() and getApiMaxRequestBytes()

### DIFF
--- a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
+++ b/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java
@@ -862,8 +862,12 @@ public class Publisher implements PublisherInterface {
       Preconditions.checkNotNull(batchingSettings);
       Preconditions.checkNotNull(batchingSettings.getElementCountThreshold());
       Preconditions.checkArgument(batchingSettings.getElementCountThreshold() > 0);
+      Preconditions.checkArgument(
+          batchingSettings.getElementCountThreshold() <= getApiMaxRequestElementCount());
       Preconditions.checkNotNull(batchingSettings.getRequestByteThreshold());
       Preconditions.checkArgument(batchingSettings.getRequestByteThreshold() > 0);
+      Preconditions.checkArgument(
+          batchingSettings.getRequestByteThreshold() <= getApiMaxRequestBytes());
       Preconditions.checkNotNull(batchingSettings.getDelayThreshold());
       Preconditions.checkArgument(batchingSettings.getDelayThreshold().toMillis() > 0);
       FlowControlSettings flowControlSettings = batchingSettings.getFlowControlSettings();

--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
@@ -964,6 +964,22 @@ public class PublisherImplTest {
     } catch (IllegalArgumentException expected) {
       // Expected
     }
+    try {
+      builder.setBatchingSettings(
+          Publisher.Builder.DEFAULT_BATCHING_SETTINGS.toBuilder()
+              .setElementCountThreshold(1001L)
+              .build());
+    } catch (IllegalArgumentException expected) {
+      // Expected
+    }
+    try {
+      builder.setBatchingSettings(
+          Publisher.Builder.DEFAULT_BATCHING_SETTINGS.toBuilder()
+              .setElementCountThreshold((10L * 1000L * 1000L) + 1L)
+              .build());
+    } catch (IllegalArgumentException expected) {
+      // Expected
+    }
   }
 
   @Test

--- a/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
+++ b/google-cloud-pubsub/src/test/java/com/google/cloud/pubsub/v1/PublisherImplTest.java
@@ -969,6 +969,7 @@ public class PublisherImplTest {
           Publisher.Builder.DEFAULT_BATCHING_SETTINGS.toBuilder()
               .setElementCountThreshold(1001L)
               .build());
+      fail("Should have thrown an IllegalArgumentException");
     } catch (IllegalArgumentException expected) {
       // Expected
     }
@@ -977,6 +978,7 @@ public class PublisherImplTest {
           Publisher.Builder.DEFAULT_BATCHING_SETTINGS.toBuilder()
               .setElementCountThreshold((10L * 1000L * 1000L) + 1L)
               .build());
+      fail("Should have thrown an IllegalArgumentException");
     } catch (IllegalArgumentException expected) {
       // Expected
     }


### PR DESCRIPTION
Enforcing max limits set by getApiMaxRequestElementCount() and getApiMaxRequestBytes().
The limits are documented in the pubsub documentation [here (Quotas and limits on batch messaging).](https://docs.cloud.google.com/pubsub/docs/batch-messaging#quotas_and_limits_on_batch_messaging)
[getApiMaxRequestElementCount()](https://github.com/googleapis/java-pubsub/blob/09c01ed8b24ce019cea629dcb0d45dacfe5f112a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java#L140) and [getApiMaxRequestBytes()](https://github.com/googleapis/java-pubsub/blob/09c01ed8b24ce019cea629dcb0d45dacfe5f112a/google-cloud-pubsub/src/main/java/com/google/cloud/pubsub/v1/Publisher.java#L145) are not new methods, just has not previously been enforced.

Suggested fix to the issue I opened: https://github.com/googleapis/google-cloud-java/issues/13042