### PR TITLE
ci: update hermetic generation workflow to use the latest image

### DIFF
--- a/.github/scripts/update_generation_config.sh
+++ b/.github/scripts/update_generation_config.sh
@@ -147,7 +147,7 @@ latest_version=$(get_latest_released_version "com.google.api" "gapic-generator-j
 update_config "gapic_generator_version" "${latest_version}" "${generation_config}"
 
 # Update composite action version to latest gapic-generator-java version
-update_action "googleapis/sdk-platform-java/.github/scripts" \
+update_action "googleapis/google-cloud-java/sdk-platform-java/.github/scripts" \
   "${latest_version}" \
   "${workflow}"
 

--- a/.github/workflows/hermetic_library_generation.yaml
+++ b/.github/workflows/hermetic_library_generation.yaml
@@ -40,6 +40,7 @@ jobs:
     - uses: googleapis/google-cloud-java/sdk-platform-java/.github/scripts@v1.85.0
       if: env.SHOULD_RUN == 'true'
       with:
+        image_tag: latest
         base_ref: ${{ github.base_ref }}
         head_ref: ${{ github.head_ref }}
         token: ${{ secrets.CLOUD_JAVA_BOT_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -26,9 +26,9 @@
         "^.github/workflows/unmanaged_dependency_check.yaml$"
       ],
       "matchStrings": [
-        "uses: googleapis/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@google-cloud-shared-dependencies/v(?<currentValue>.+?)\\n"
+        "uses: googleapis/google-cloud-java/sdk-platform-java/java-shared-dependencies/unmanaged-dependency-check@v(?<currentValue>.+?)\\n"
       ],
-      "depNameTemplate": "com.google.cloud:sdk-platform-java-config",
+      "depNameTemplate": "com.google.cloud:gapic-libraries-bom",
       "datasourceTemplate": "maven"
     }
   ],


### PR DESCRIPTION
We moved the definition of the workflow files from sdk-platform-java repository to the sdk-platform-java folder in the google-cloud-java repository.

This uses the "latest" Docker tag in .github/workflows/hermetic_library_generation.yaml to confirm the behavior of the today's hermetic build container image update.

b/503444342
